### PR TITLE
Incorporate Personal leaderboard API and docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,43 @@ Run the backend on port 5001 and seed example data, then start the frontend.
   - `REACT_APP_API_BASE=http://localhost:5001 npm start`
 - Open the Evaluations page to see demo scores populate.
 
+4) Optional docs site
+- Install MkDocs Material:
+  - `pip install mkdocs-material`
+- Serve the documentation:
+  - `mkdocs serve`
+- Open `http://127.0.0.1:8000`.
+
 Notes
 - The demo uses an in-memory store by default (no DB needed).
 - If you configure MySQL and load `backend/database/schema.sql`, the API will persist to DB.
+- Hugging Face imports require the optional `datasets` package:
+  - `pip install datasets`
+
+---
+
+## Metrics and Hugging Face Imports
+
+The API exposes metric metadata copied into this Flask app from the newer Personal implementation:
+
+- `GET /api/metrics` lists all known metric definitions.
+- `GET /api/metrics/task/<task_type>` lists recommended metrics for a task type.
+
+You can import a bounded Hugging Face dataset split into the leaderboard:
+
+```bash
+curl -X POST http://localhost:5001/public/import_hf_dataset \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dataset_name": "ag_news",
+    "split": "test",
+    "limit": 100,
+    "task_type": "text_classification",
+    "display_name": "AG News Test Sample"
+  }'
+```
+
+Use `"preview_only": true` to inspect the converted payload without saving it. Imported datasets are stored in MySQL when configured, otherwise in the local in-memory store for development.
 
 ---
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -57,6 +57,17 @@ try:
 except Exception:
     csv_bench = None
 
+try:
+    from metrics_info import METRICS_CATALOG, metrics_for_task  # type: ignore
+except Exception:
+    try:
+        from backend.metrics_info import METRICS_CATALOG, metrics_for_task  # type: ignore
+    except Exception:
+        METRICS_CATALOG = {}
+
+        def metrics_for_task(_task_type):
+            return {}
+
 
 # Root welcome endpoint for quick sanity check
 @app.get('/')
@@ -106,6 +117,7 @@ def _get_bleu(translations, references, weights=(0.5, 0.5, 0, 0)):
 _STORE = {
     "submissions": [],  # {id, benchmark_dataset_name, model_name, results, created}
     "evaluations": [],  # {submission_id, score, metric, created}
+    "datasets": [],  # {name, task_type, evaluation_metric, reference_data}
 }
 
 # UI-oriented datasets store (for add_dataset/add_model endpoints)
@@ -291,6 +303,9 @@ def submit_model():
             except Exception:
                 pass
 
+    if not dataset:
+        dataset = next((d for d in _STORE["datasets"] if d.get("name") == benchmark_dataset_name), None)
+
     task_type = None
     metric = None
     reference_sentences = None
@@ -407,7 +422,7 @@ def submit_model():
                 parts = [p.strip() for p in str(out).split(';') if p and str(p).strip()]
                 pred_lists.append(parts)
             score = _f1_entities(reference_entities, pred_lists)
-        elif tt in ('chatbot', 'prompting', 'qa'):
+        elif tt in ('chatbot', 'prompting', 'qa', 'document_qa', 'line_qa'):
             if not reference_answers:
                 return jsonify({"success": False, "error": "Dataset does not have reference answers"}), 400
             metric = (metric or 'exact').lower()
@@ -563,6 +578,16 @@ def list_public_datasets():
             "url": ds.get("url"),
             "description": ds.get("description"),
         })
+    for ds in _STORE["datasets"]:
+        rd = ds.get("reference_data") if isinstance(ds.get("reference_data"), dict) else {}
+        fallback.append({
+            "name": ds.get("name"),
+            "task_type": ds.get("task_type"),
+            "evaluation_metric": ds.get("evaluation_metric", ""),
+            "url": rd.get("url"),
+            "description": rd.get("description"),
+            "size": len(rd.get("source_texts", [])) if isinstance(rd.get("source_texts"), list) else None,
+        })
     return jsonify({"success": True, "datasets": fallback})
 
 
@@ -593,6 +618,15 @@ def add_dataset_public():
     conn, cursor = get_db_connection()
     if not (conn and cursor):
         # In-memory: store a shadow dataset in curated data for dev
+        existing = next((d for d in _STORE["datasets"] if d.get("name") == name), None)
+        if existing:
+            return jsonify({"success": False, "error": "Dataset with this name already exists"}), 400
+        _STORE["datasets"].append({
+            "name": name,
+            "task_type": task_type,
+            "evaluation_metric": evaluation_metric,
+            "reference_data": reference_data,
+        })
         LEADERBOARD_DATA.append({
             "id": str(uuid.uuid4()),
             "name": name,
@@ -686,6 +720,18 @@ def dataset_details():
 
     # Fallback: find in curated list and memory submissions
     matched = next((d for d in LEADERBOARD_DATA if d.get('name') == name), None)
+    stored = next((d for d in _STORE["datasets"] if d.get("name") == name), None)
+    if stored:
+        rd = stored.get("reference_data") if isinstance(stored.get("reference_data"), dict) else {}
+        matched = {
+            "name": stored.get("name"),
+            "task_type": stored.get("task_type"),
+            "evaluation_metric": stored.get("evaluation_metric"),
+            "url": rd.get("url"),
+            "description": rd.get("description"),
+            "size": len(rd.get("source_texts", [])) if isinstance(rd.get("source_texts"), list) else None,
+            "examples": rd.get("source_texts", [])[:5] if isinstance(rd.get("source_texts"), list) else [],
+        }
     if not matched and name.startswith('flores_spanish_translation'):
         matched = {"name": name, "task_type": "translation", "evaluation_metric": "bleu", "description": "FLORES-style demo", "url": None}
     if not matched:
@@ -697,7 +743,7 @@ def dataset_details():
         if sub and sub['benchmark_dataset_name'] == name:
             mem.append({"model": sub['model_name'], "score": ev['score'], "updated": sub['created'].isoformat()})
     mem.sort(key=lambda x: x['score'], reverse=True)
-    examples = _SPANISH_REFERENCES[:5]
+    examples = matched.get("examples") or _SPANISH_REFERENCES[:5]
     return jsonify({
         "success": True,
         "dataset": {
@@ -710,6 +756,93 @@ def dataset_details():
             "examples": examples,
         },
         "top_models": mem[:10],
+    })
+
+
+@app.get('/api/metrics')
+def list_metrics():
+    """Return metric metadata for UI help text and docs clients."""
+    return jsonify({"success": True, "metrics": METRICS_CATALOG})
+
+
+@app.get('/api/metrics/task/<task_type>')
+def list_task_metrics(task_type):
+    """Return recommended metrics for a specific task type."""
+    return jsonify({"success": True, "task_type": task_type, "metrics": metrics_for_task(task_type)})
+
+
+@app.post('/public/import_hf_dataset')
+def import_hf_dataset_public():
+    """Import a bounded Hugging Face dataset split into benchmark_datasets/reference_data."""
+    data = request.get_json(silent=True) or {}
+    try:
+        try:
+            from hf_importer import import_hf_dataset  # type: ignore
+        except Exception:
+            from backend.hf_importer import import_hf_dataset  # type: ignore
+        payload = import_hf_dataset(
+            dataset_name=data.get("dataset_name") or data.get("name"),
+            config=data.get("config"),
+            split=data.get("split", "test"),
+            limit=int(data.get("limit", 100)),
+            task_type=data.get("task_type"),
+            display_name=data.get("display_name"),
+        )
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)}), 400
+
+    if data.get("preview_only"):
+        preview = dict(payload)
+        rd = dict(preview.get("reference_data") or {})
+        rd["source_texts"] = rd.get("source_texts", [])[:5]
+        rd["ground_truth"] = rd.get("ground_truth", [])[:5]
+        preview["reference_data"] = rd
+        return jsonify({"success": True, "dataset": preview})
+
+    conn, cursor = get_db_connection()
+    if conn and cursor:
+        try:
+            cursor.execute(
+                "INSERT INTO benchmark_datasets (name, task_type, evaluation_metric, reference_data, active) VALUES (%s, %s, %s, %s, TRUE)",
+                (
+                    payload["name"],
+                    payload["task_type"],
+                    payload["evaluation_metric"],
+                    json.dumps(payload["reference_data"]),
+                ),
+            )
+            conn.commit()
+        except Exception as e:
+            if 'Duplicate' in str(e) or 'UNIQUE' in str(e):
+                return jsonify({"success": False, "error": "Dataset with this name already exists"}), 400
+            return jsonify({"success": False, "error": "Failed to import dataset"}), 500
+        finally:
+            try:
+                cursor.close(); conn.close()
+            except Exception:
+                pass
+    else:
+        if any(d.get("name") == payload["name"] for d in _STORE["datasets"]):
+            return jsonify({"success": False, "error": "Dataset with this name already exists"}), 400
+        _STORE["datasets"].append(payload)
+        LEADERBOARD_DATA.append({
+            "id": str(uuid.uuid4()),
+            "name": payload["name"],
+            "task_type": payload["task_type"],
+            "description": payload["reference_data"].get("description"),
+            "url": payload["reference_data"].get("url"),
+            "models": [],
+        })
+
+    return jsonify({
+        "success": True,
+        "message": "Dataset imported",
+        "dataset": {
+            "name": payload["name"],
+            "task_type": payload["task_type"],
+            "evaluation_metric": payload["evaluation_metric"],
+            "size": len(payload["reference_data"].get("source_texts", [])),
+        },
     })
 
 

--- a/backend/hf_importer.py
+++ b/backend/hf_importer.py
@@ -1,0 +1,133 @@
+"""Small Hugging Face dataset importer for the Flask leaderboard.
+
+The Personal repo contains a broader FastAPI/SQLAlchemy importer. This module
+keeps the useful conversion behavior while matching this repo's lightweight
+Flask API and optional dependency posture.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+TASK_DEFAULTS = {
+    "text_classification": {"primary_metric": "accuracy", "answer_keys": ["label", "label_text", "answer"]},
+    "document_qa": {"primary_metric": "exact", "answer_keys": ["answers", "answer"]},
+    "line_qa": {"primary_metric": "exact", "answer_keys": ["answers", "answer"]},
+    "translation": {"primary_metric": "bleu", "answer_keys": ["translation", "target", "answer"]},
+}
+
+KNOWN_DATASETS = {
+    "ag_news": "text_classification",
+    "imdb": "text_classification",
+    "nyu-mll/glue": "text_classification",
+    "squad": "document_qa",
+    "rajpurkar/squad": "document_qa",
+}
+
+
+class HuggingFaceImportError(Exception):
+    """Raised when a Hugging Face dataset cannot be loaded or converted."""
+
+
+def _load_dataset(dataset_name: str, config: Optional[str], split: str):
+    try:
+        from datasets import load_dataset
+    except Exception as exc:
+        raise HuggingFaceImportError(
+            "Install the optional 'datasets' package to import Hugging Face datasets."
+        ) from exc
+
+    try:
+        if config:
+            return load_dataset(dataset_name, config, split=split)
+        return load_dataset(dataset_name, split=split)
+    except Exception as exc:
+        raise HuggingFaceImportError(f"Failed to load {dataset_name} ({split}): {exc}") from exc
+
+
+def infer_task_type(dataset_name: str, requested_task_type: Optional[str] = None) -> str:
+    if requested_task_type:
+        return requested_task_type
+    return KNOWN_DATASETS.get(dataset_name, "text_classification")
+
+
+def _first_present(row: Dict[str, Any], keys: List[str]) -> Any:
+    for key in keys:
+        if key in row and row[key] is not None:
+            return row[key]
+    return None
+
+
+def _answer_from_row(row: Dict[str, Any], task_type: str) -> Any:
+    answer = _first_present(row, TASK_DEFAULTS.get(task_type, TASK_DEFAULTS["text_classification"])["answer_keys"])
+    if isinstance(answer, dict) and isinstance(answer.get("text"), list):
+        return answer["text"][0] if len(answer["text"]) == 1 else answer["text"]
+    if isinstance(answer, dict):
+        return next(iter(answer.values()), "")
+    if isinstance(answer, list) and len(answer) == 1:
+        return answer[0]
+    return answer
+
+
+def _question_from_row(row: Dict[str, Any]) -> str:
+    value = _first_present(row, ["question", "sentence", "text", "context", "premise", "review", "input"])
+    if value is None:
+        return str(row)
+    return str(value)
+
+
+def import_hf_dataset(
+    dataset_name: str,
+    config: Optional[str] = None,
+    split: str = "test",
+    limit: int = 100,
+    task_type: Optional[str] = None,
+    display_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Load a bounded HF split and convert it to this leaderboard's reference_data shape."""
+    if not dataset_name:
+        raise HuggingFaceImportError("dataset_name is required")
+    if limit < 1 or limit > 5000:
+        raise HuggingFaceImportError("limit must be between 1 and 5000")
+
+    resolved_task_type = infer_task_type(dataset_name, task_type)
+    metric = TASK_DEFAULTS.get(resolved_task_type, TASK_DEFAULTS["text_classification"])["primary_metric"]
+    ds = _load_dataset(dataset_name, config, split)
+    count = min(limit, len(ds))
+
+    source_texts = []
+    answers = []
+    labels = []
+    ground_truth = []
+    for idx in range(count):
+        row = dict(ds[idx])
+        question = _question_from_row(row)
+        answer = _answer_from_row(row, resolved_task_type)
+        source_texts.append(question)
+        if resolved_task_type == "text_classification":
+            labels.append(str(answer))
+        else:
+            answers.append(answer)
+        ground_truth.append({"id": idx, "question": question, "answer": answer})
+
+    reference_data: Dict[str, Any] = {
+        "url": f"https://huggingface.co/datasets/{dataset_name}",
+        "description": f"Imported from Hugging Face dataset {dataset_name}, split={split}.",
+        "source_texts": source_texts,
+        "ground_truth": ground_truth,
+        "hf_dataset": dataset_name,
+        "hf_config": config,
+        "hf_split": split,
+    }
+    if labels:
+        reference_data["labels"] = labels
+    if answers:
+        reference_data["answers"] = answers
+
+    return {
+        "name": display_name or f"{dataset_name} ({split})",
+        "task_type": resolved_task_type,
+        "evaluation_metric": metric,
+        "reference_data": reference_data,
+    }

--- a/backend/metrics_info.py
+++ b/backend/metrics_info.py
@@ -1,0 +1,92 @@
+"""Metric catalog exposed by the public leaderboard API.
+
+This is a Flask-friendly subset of the richer metric documentation from the
+Personal leaderboard implementation.
+"""
+
+METRICS_CATALOG = {
+    "accuracy": {
+        "name": "Accuracy",
+        "formula": "correct predictions / total predictions",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Share of examples where the model prediction exactly matches the expected label.",
+        "task_types": ["text_classification", "multiple_choice"],
+    },
+    "precision": {
+        "name": "Macro Precision",
+        "formula": "mean(TP / (TP + FP)) across classes",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "How often predicted labels are correct, averaged across classes.",
+        "task_types": ["text_classification", "named_entity_recognition", "ner"],
+    },
+    "recall": {
+        "name": "Macro Recall",
+        "formula": "mean(TP / (TP + FN)) across classes",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "How often expected labels are recovered, averaged across classes.",
+        "task_types": ["text_classification", "named_entity_recognition", "ner"],
+    },
+    "f1": {
+        "name": "F1",
+        "formula": "2 * precision * recall / (precision + recall)",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Harmonic mean of precision and recall.",
+        "task_types": ["text_classification", "named_entity_recognition", "ner", "document_qa", "line_qa", "qa"],
+    },
+    "exact": {
+        "name": "Exact Match",
+        "formula": "normalized prediction == normalized answer",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Strict answer match after lowercase and whitespace normalization.",
+        "task_types": ["chatbot", "prompting", "document_qa", "line_qa", "qa"],
+    },
+    "exact_match": {
+        "name": "Exact Match",
+        "formula": "normalized prediction == normalized answer",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Strict answer match after lowercase and whitespace normalization.",
+        "task_types": ["chatbot", "prompting", "document_qa", "line_qa", "qa"],
+    },
+    "bleu": {
+        "name": "BLEU",
+        "formula": "n-gram overlap with brevity penalty",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Translation overlap score against reference translations.",
+        "task_types": ["translation"],
+    },
+    "bertscore": {
+        "name": "BERTScore",
+        "formula": "contextual embedding similarity",
+        "range": "0.0 - 1.0",
+        "higher_is_better": True,
+        "description": "Semantic similarity between generated text and references when the optional bert_score package is installed.",
+        "task_types": ["translation", "document_qa", "line_qa", "qa"],
+    },
+}
+
+
+TASK_METRICS = {
+    "text_classification": ["accuracy", "f1", "precision", "recall"],
+    "multiple_choice": ["accuracy"],
+    "translation": ["bleu", "bertscore"],
+    "ner": ["f1", "precision", "recall"],
+    "named_entity_recognition": ["f1", "precision", "recall"],
+    "chatbot": ["exact", "f1"],
+    "prompting": ["exact", "f1"],
+    "qa": ["exact", "f1", "bertscore"],
+    "document_qa": ["exact_match", "f1", "bertscore"],
+    "line_qa": ["exact_match", "f1", "bertscore"],
+}
+
+
+def metrics_for_task(task_type):
+    """Return metric metadata for a task type."""
+    keys = TASK_METRICS.get(str(task_type or "").lower(), [])
+    return {key: METRICS_CATALOG[key] for key in keys if key in METRICS_CATALOG}

--- a/backend/pytest/test_dataset_endpoints.py
+++ b/backend/pytest/test_dataset_endpoints.py
@@ -10,6 +10,7 @@ def _clean_state():
     LEADERBOARD_DATA.clear()
     _STORE['submissions'].clear()
     _STORE['evaluations'].clear()
+    _STORE['datasets'].clear()
     yield
 
 
@@ -116,3 +117,41 @@ def test_ner_and_qa_flows():
     data = res.get_json()
     assert data["success"] is True
     assert 0.9 <= data["score"] <= 1.0
+
+
+def test_metrics_catalog_endpoints():
+    client = app.test_client()
+
+    res = client.get('/api/metrics')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["success"] is True
+    assert "accuracy" in data["metrics"]
+
+    res = client.get('/api/metrics/task/text_classification')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["success"] is True
+    assert "accuracy" in data["metrics"]
+
+
+def test_in_memory_dataset_reference_data_scores_classification():
+    client = app.test_client()
+    client.post('/public/add_dataset', json={
+        "name": "stored_classification",
+        "task_type": "text_classification",
+        "evaluation_metric": "accuracy",
+        "reference_data": {"source_texts": ["a", "b"], "labels": ["yes", "no"]}
+    })
+
+    res = client.post('/public/submit_model', json={
+        "benchmarkDatasetName": "stored_classification",
+        "modelName": "classifier",
+        "modelResults": ["yes", "wrong"],
+        "sentence_ids": [0, 1]
+    })
+
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["success"] is True
+    assert data["score"] == 0.5

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,50 @@
+# API Usage
+
+## Dataset Discovery
+
+```bash
+curl http://localhost:5001/public/datasets
+curl "http://localhost:5001/public/dataset_details?name=flores_spanish_translation"
+```
+
+## Metric Metadata
+
+```bash
+curl http://localhost:5001/api/metrics
+curl http://localhost:5001/api/metrics/task/text_classification
+```
+
+## Add a Dataset
+
+```bash
+curl -X POST http://localhost:5001/public/add_dataset \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "demo_classification",
+    "task_type": "text_classification",
+    "evaluation_metric": "accuracy",
+    "reference_data": {
+      "source_texts": ["good", "bad"],
+      "labels": ["positive", "negative"]
+    }
+  }'
+```
+
+## Submit Model Outputs
+
+```bash
+curl -X POST http://localhost:5001/public/submit_model \
+  -H "Content-Type: application/json" \
+  -d '{
+    "benchmarkDatasetName": "demo_classification",
+    "modelName": "my-model",
+    "modelResults": ["positive", "negative"],
+    "sentence_ids": [0, 1]
+  }'
+```
+
+## View Leaderboard
+
+```bash
+curl http://localhost:5001/public/get_leaderboard
+```

--- a/docs/huggingface-imports.md
+++ b/docs/huggingface-imports.md
@@ -1,0 +1,43 @@
+# Hugging Face Imports
+
+Install the optional dependency first:
+
+```bash
+pip install datasets
+```
+
+Preview a conversion:
+
+```bash
+curl -X POST http://localhost:5001/public/import_hf_dataset \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dataset_name": "ag_news",
+    "split": "test",
+    "limit": 25,
+    "task_type": "text_classification",
+    "preview_only": true
+  }'
+```
+
+Persist the imported dataset:
+
+```bash
+curl -X POST http://localhost:5001/public/import_hf_dataset \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dataset_name": "ag_news",
+    "split": "test",
+    "limit": 100,
+    "task_type": "text_classification",
+    "display_name": "AG News Test Sample"
+  }'
+```
+
+When MySQL is configured, imported datasets are written to `benchmark_datasets`. Without MySQL, they live in the Flask in-memory store until the process restarts.
+
+## Supported Conversion Defaults
+
+- `text_classification`: stores `source_texts` and `labels`; default metric is `accuracy`.
+- `document_qa` and `line_qa`: stores `source_texts` and `answers`; default metric is `exact`.
+- `translation`: stores `source_texts` and `answers`; default metric is `bleu`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Anote Leaderboard
+
+The leaderboard benchmarks model submissions against public or curated datasets. This repo runs a Flask API, a React frontend, optional MySQL persistence, CSV benchmark runners, and a lightweight Hugging Face dataset import path.
+
+## What You Can Do
+
+- Add benchmark datasets.
+- Fetch source questions or sentences for a dataset.
+- Submit model outputs for scoring.
+- View ranked leaderboard entries.
+- Inspect metric definitions by task type.
+- Import bounded Hugging Face splits for local or persisted evaluation.
+
+The frontend keeps the existing Anote dark UI. The imported Personal repo functionality is integrated at the API layer instead of replacing the current app structure.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,28 @@
+# Operations
+
+## Persistence
+
+Local development works without a database. The API stores custom datasets, imported datasets, submissions, and evaluations in memory.
+
+For persistence, configure MySQL environment variables and load `backend/database/schema.sql`:
+
+```bash
+export DB_HOST=localhost
+export DB_USER=root
+export DB_PASSWORD=
+export DB_NAME=agents
+export DB_PORT=3306
+```
+
+## Configuration
+
+- `PORT`: Flask port. Use `5001` for the current frontend default.
+- `ALLOWED_ORIGINS`: comma-separated CORS origins. Defaults to `*` for local development.
+- `REACT_APP_API_BASE`: frontend API base URL.
+
+## Remaining Known Gaps
+
+- Hugging Face imports are synchronous and bounded by `limit`.
+- Imported label names are generic for datasets that expose numeric labels without feature metadata.
+- The in-memory store is for development only.
+- MySQL schema migrations are not yet versioned.

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -1,0 +1,43 @@
+# Running Locally
+
+## Backend
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+export PORT=5001 FLASK_ENV=development
+python backend/app.py
+```
+
+Health check:
+
+```bash
+curl http://localhost:5001/health
+```
+
+## Seed Demo Data
+
+```bash
+export LEADERBOARD_API_BASE=http://localhost:5001
+python backend/examples/seed_demo.py
+```
+
+## Frontend
+
+```bash
+cd frontend
+npm install
+REACT_APP_API_BASE=http://localhost:5001 npm start
+```
+
+Open `http://localhost:3000`.
+
+## Docs
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000`.

--- a/frontend/src/landing_page/landing_page_components/DatasetDetails.js
+++ b/frontend/src/landing_page/landing_page_components/DatasetDetails.js
@@ -9,6 +9,7 @@ const DatasetDetails = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [data, setData] = useState(null);
+  const [metrics, setMetrics] = useState({});
 
   useEffect(() => {
     let ignore = false;
@@ -21,6 +22,13 @@ const DatasetDetails = () => {
         const json = await res.json();
         if (!res.ok || json.success !== true) throw new Error(json.error || 'Failed to fetch dataset');
         if (!ignore) setData(json);
+        if (json.dataset?.task_type) {
+          const metricsRes = await fetch(`${API_BASE}/api/metrics/task/${encodeURIComponent(json.dataset.task_type)}`);
+          const metricsJson = await metricsRes.json();
+          if (!ignore && metricsRes.ok && metricsJson.success === true) {
+            setMetrics(metricsJson.metrics || {});
+          }
+        }
       } catch (e) {
         if (!ignore) setError(e.message || 'Error loading dataset');
       } finally {
@@ -59,6 +67,20 @@ const DatasetDetails = () => {
                 </ul>
               </div>
             )}
+            {Object.keys(metrics).length > 0 && (
+              <div className="mt-6">
+                <div className="text-white font-semibold mb-2">Metrics</div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {Object.entries(metrics).map(([key, metric]) => (
+                    <div key={key} className="border border-gray-800 rounded-lg p-3 bg-gray-950">
+                      <div className="text-[#EDDC8F] font-semibold">{metric.name || key}</div>
+                      <div className="text-gray-300 text-sm mt-1">{metric.description}</div>
+                      <div className="text-gray-500 text-xs mt-2">{metric.range}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             <div className="mt-6">
               <div className="text-white font-semibold mb-2">Top Models</div>
               {data.top_models && data.top_models.length ? (
@@ -86,4 +108,3 @@ const DatasetDetails = () => {
 };
 
 export default DatasetDetails;
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: Anote Leaderboard
+site_description: Local and API documentation for the Anote model leaderboard.
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.instant
+    - content.code.copy
+nav:
+  - Home: index.md
+  - Running Locally: running-locally.md
+  - API Usage: api.md
+  - Hugging Face Imports: huggingface-imports.md
+  - Operations: operations.md
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
## Summary
- add metric catalog endpoints and task-specific metric metadata from the Personal implementation
- add a Flask-compatible Hugging Face dataset import endpoint with preview and in-memory/MySQL persistence
- preserve in-memory reference data so local custom datasets score correctly
- surface task metric descriptions on dataset details without changing the existing UI style
- add README run instructions and MkDocs Material documentation

## Tests
- python3 -m pytest backend/pytest -q
- npm run build
- mkdocs build --strict