### PR TITLE
Integrate Personal leaderboard features and issue fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
+      - run: npm ci --legacy-peer-deps
         working-directory: frontend
       - run: npm run lint
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r backend/requirements.txt pytest ruff mkdocs-material
+      - run: python -m pytest backend/pytest -q
+      - run: ruff check backend
+      - run: mkdocs build --strict
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run lint
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         working-directory: frontend
       - run: npm run build
         working-directory: frontend
+        env:
+          CI: "false"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,12 @@ When running locally, override with `REACT_APP_API_ENDPOINT=http://localhost:500
 | GET | `/public/get_source_sentences` | Sentences to translate (for evaluation) |
 | POST | `/public/submit_model` | Submit model predictions for scoring |
 | GET | `/public/get_leaderboard` | Ranked model results |
+| GET | `/public/export/leaderboard` | Export leaderboard rows |
+| POST | `/public/import_hf_dataset` | Import a Hugging Face dataset split |
+| POST | `/api/datasets/ingest` | Ingestion-compatible dataset import endpoint |
+| GET | `/api/metrics` | Metric catalog |
+| GET | `/api/metrics/task/<task_type>` | Task-specific metric catalog |
+| GET | `/openapi.json` | Machine-readable API description |
 | GET | `/public/benchmark_csvs` | List CSV benchmark files |
 | POST | `/public/run_csv_benchmarks` | Benchmark models against CSV datasets |
 | POST | `/api/leaderboard/add_dataset` | Add a new benchmark dataset |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,15 @@ LEADERBOARD_API_BASE=http://localhost:5001 python backend/examples/seed_demo.py
 | `DB_PASSWORD` | — | MySQL password |
 | `DB_NAME` | `agents` | MySQL database |
 | `DB_PORT` | `3306` | MySQL port |
-| `ALLOWED_ORIGINS` | `*` | CORS allowed origins |
+| `ALLOWED_ORIGINS` | local React origins in development | CORS allowed origins. Required outside development. |
 | `LEADERBOARD_API_BASE` | `http://localhost:5001` | Used by seed/test scripts |
+| `LEADERBOARD_API_KEYS` | — | Comma-separated API keys. When set, write endpoints require `X-API-Key`. |
+| `REQUIRE_API_KEY` | — | Set to `true` to enforce API-key auth. |
+| `SUBMIT_MODEL_RATE_LIMIT` | `10/minute` | Per-IP write limit for submissions. |
+| `ADD_DATASET_RATE_LIMIT` | `5/minute` | Per-IP write limit for dataset creation. |
+| `IMPORT_DATASET_RATE_LIMIT` | `5/minute` | Per-IP write limit for imports. |
+| `RUN_CSV_RATE_LIMIT` | `5/minute` | Per-IP write limit for CSV benchmark runs. |
+| `TRUSTED_REMOTE_CODE_MODELS` | — | Explicit allowlist for Hugging Face model ids that may use remote code. |
 
 **No API keys are required to run the platform.** API keys are only needed if you want to evaluate GPT-4, Claude, Gemini, etc.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ Notes
   - `echo`: returns a dummy output (useful for dry-runs).
   - `py`: calls a Python function from `backend/models.py` (see below).
 
+#### Additional Public API Utilities
+
+- `GET /api/metrics`: list metric metadata.
+- `GET /api/metrics/task/<task_type>`: list recommended metrics for a task type.
+- `POST /public/import_hf_dataset`: import a bounded Hugging Face split.
+- `POST /api/datasets/ingest`: ingestion-compatible alias for Hugging Face imports.
+- `GET /public/export/leaderboard?format=csv|json`: export leaderboard rows.
+
+Optional write protection:
+- Set `LEADERBOARD_API_KEYS=key1,key2` to require `X-API-Key` on write/evaluation endpoints.
+- Set per-endpoint rate limits with values such as `SUBMIT_MODEL_RATE_LIMIT=10/minute`.
+- Set `ALLOWED_ORIGINS` explicitly outside local development.
+
 ---
 
 ### Models Catalog (`backend/models.py`)
@@ -254,6 +267,18 @@ curl -X POST http://localhost:5001/public/import_hf_dataset \
 ```
 
 Use `"preview_only": true` to inspect the converted payload without saving it. Imported datasets are stored in MySQL when configured, otherwise in the local in-memory store for development.
+
+Leaderboard reads support pagination and dataset filtering:
+
+```bash
+curl "http://localhost:5001/public/get_leaderboard?page=1&page_size=25&dataset=AG%20News%20Test%20Sample"
+```
+
+Exports are available as JSON or CSV:
+
+```bash
+curl "http://localhost:5001/public/export/leaderboard?format=csv" -o leaderboard.csv
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ Run the backend on port 5001 and seed example data, then start the frontend.
   - `REACT_APP_API_BASE=http://localhost:5001 npm start`
 - Open the Evaluations page to see demo scores populate.
 
+Docker option:
+- `docker compose up --build`
+- Open `http://localhost:3000` and use `http://localhost:5001` for the API.
+
 4) Optional docs site
 - Install MkDocs Material:
   - `pip install mkdocs-material`

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt /app/backend/requirements.txt
+RUN pip install --no-cache-dir -r /app/backend/requirements.txt
+
+COPY . /app/backend
+
+ENV PORT=5001
+EXPOSE 5001
+
+CMD ["python", "backend/app.py"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,15 @@
 import os
 import json
-from datetime import datetime
-from flask import Flask, request, jsonify
+import csv
+import logging
+import re
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from functools import wraps
+from io import StringIO
+from time import time
+
+from flask import Flask, Response, request, jsonify
 from flask_cors import CORS
 import uuid
 
@@ -37,19 +45,125 @@ def get_db_connection():
         return conn, cursor
     except Exception as e:
         # Database might not be configured in local dev. Return None to use in-memory fallback.
-        print(f"Warning: DB connection not available: {e}")
+        logger.warning("db_connection_unavailable", extra={"error": str(e)})
         return None, None
 
 
 app = Flask(__name__)
 app.config['JSON_SORT_KEYS'] = False
-# Allow overriding CORS origins via ALLOWED_ORIGINS env (comma-separated). Defaults to permissive for local dev.
-_origins = os.getenv('ALLOWED_ORIGINS')
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
+logger = logging.getLogger("leaderboard")
+
+# Allow overriding CORS origins via ALLOWED_ORIGINS env (comma-separated).
+_flask_env = os.getenv("FLASK_ENV", "development").lower()
+_origins = os.getenv("ALLOWED_ORIGINS")
 if _origins:
-    _origins_list = [o.strip() for o in _origins.split(',') if o.strip()]
+    _origins_list = [origin.strip() for origin in _origins.split(",") if origin.strip()]
+elif _flask_env == "development":
+    _origins_list = ["http://localhost:3000", "http://127.0.0.1:3000"]
 else:
-    _origins_list = ['*']
+    raise RuntimeError("ALLOWED_ORIGINS must be set outside development")
 CORS(app, resources={r"/*": {"origins": _origins_list}})
+
+
+@app.after_request
+def add_compatible_response_envelope(response):
+    """Add `ok` without removing legacy `success`/`status` fields."""
+    if response.mimetype != "application/json":
+        return response
+    try:
+        payload = response.get_json(silent=True)
+    except Exception:
+        return response
+    if not isinstance(payload, dict) or "ok" in payload:
+        return response
+    if "success" in payload:
+        payload["ok"] = bool(payload["success"])
+    elif payload.get("status") == "success":
+        payload["ok"] = True
+    elif payload.get("status") == "error" or "error" in payload:
+        payload["ok"] = False
+    else:
+        payload["ok"] = 200 <= response.status_code < 400
+    response.set_data(json.dumps(payload))
+    response.content_length = len(response.get_data())
+    return response
+
+
+def utc_now():
+    return datetime.now(timezone.utc)
+
+
+def validate_text(value, field, max_len=200):
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} cannot be empty")
+    value = value.strip()
+    if len(value) > max_len:
+        raise ValueError(f"{field} exceeds {max_len} characters")
+    return value
+
+
+def validate_metadata(value):
+    if value in (None, ""):
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("metadata must be a JSON object")
+    encoded = json.dumps(value)
+    if len(encoded.encode("utf-8")) > 4096:
+        raise ValueError("metadata exceeds 4 KB")
+    return value
+
+
+def require_api_key(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        configured = [key.strip() for key in os.getenv("LEADERBOARD_API_KEYS", "").split(",") if key.strip()]
+        require_key = os.getenv("REQUIRE_API_KEY", "").lower() in {"1", "true", "yes"} or bool(configured)
+        if not require_key:
+            return fn(*args, **kwargs)
+        supplied = request.headers.get("X-API-Key", "")
+        if supplied not in configured:
+            logger.warning("unauthorized_write", extra={"endpoint": request.path, "ip": request.remote_addr})
+            return jsonify({"success": False, "error": "Unauthorized"}), 401
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+_RATE_WINDOWS = defaultdict(deque)
+
+
+def rate_limit(env_name, default_limit):
+    """Small in-process limiter for write/evaluation endpoints.
+
+    Format: count/minute, for example 10/minute. Set DISABLE_RATE_LIMIT=1 to bypass.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if os.getenv("DISABLE_RATE_LIMIT", "").lower() in {"1", "true", "yes"}:
+                return fn(*args, **kwargs)
+            raw_limit = os.getenv(env_name, default_limit)
+            match = re.match(r"^(\d+)/minute$", raw_limit)
+            if not match:
+                return fn(*args, **kwargs)
+            max_calls = int(match.group(1))
+            now = time()
+            key = (request.remote_addr or "unknown", request.path)
+            window = _RATE_WINDOWS[key]
+            while window and now - window[0] > 60:
+                window.popleft()
+            if len(window) >= max_calls:
+                return jsonify({"success": False, "error": "Rate limit exceeded"}), 429
+            window.append(now)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 # Lazy import to avoid import-time failures if files not present
 try:
@@ -90,7 +204,7 @@ def index():
 # Simple health endpoint
 @app.get('/health')
 def health():
-    return jsonify({"ok": True, "time": datetime.utcnow().isoformat()})
+    return jsonify({"ok": True, "time": utc_now().isoformat()})
 
 
 # ---------------------------
@@ -169,7 +283,8 @@ def get_source_sentences():
                     pool = None
         finally:
             try:
-                cursor.close(); conn.close()
+                cursor.close()
+                conn.close()
             except Exception:
                 pass
 
@@ -200,25 +315,52 @@ def get_leaderboard():
     """Get leaderboard showing model submissions and scores.
     Supports DB if configured, otherwise returns in-memory results.
     """
-    limit = int(request.args.get('limit', 100))
+    dataset_filter = request.args.get("dataset")
+    page = max(1, int(request.args.get("page", 1)))
+    page_size = min(100, max(1, int(request.args.get("page_size", request.args.get("limit", 25)))))
+    offset = (page - 1) * page_size
     conn, cursor = get_db_connection()
 
     if conn and cursor:
         try:
-            query = (
-                "SELECT ms.model_name, bd.name AS dataset_name, bd.task_type, bd.evaluation_metric, "
-                "er.score, ms.created AS submitted_at "
+            where = "WHERE bd.active = TRUE"
+            params = []
+            if dataset_filter:
+                where += " AND bd.name = %s"
+                params.append(dataset_filter)
+
+            count_query = (
+                "SELECT COUNT(*) AS total "
                 "FROM model_submissions ms "
                 "JOIN benchmark_datasets bd ON ms.benchmark_dataset_id = bd.id "
                 "JOIN evaluation_results er ON er.model_submission_id = ms.id "
-                "WHERE bd.active = TRUE "
-                "ORDER BY bd.name, er.score DESC "
-                "LIMIT %s"
+                f"{where}"
             )
-            cursor.execute(query, (limit,))
+            cursor.execute(count_query, tuple(params))
+            total_row = cursor.fetchone() or {}
+            total = int(total_row.get("total", 0))
+
+            query = (
+                "SELECT ms.model_name, bd.name AS dataset_name, bd.task_type, bd.evaluation_metric, "
+                "er.score, er.evaluation_details, ms.created AS submitted_at, "
+                "ms.submitted_by, ms.model_results "
+                "FROM model_submissions ms "
+                "JOIN benchmark_datasets bd ON ms.benchmark_dataset_id = bd.id "
+                "JOIN evaluation_results er ON er.model_submission_id = ms.id "
+                f"{where} "
+                "ORDER BY bd.name, er.score DESC "
+                "LIMIT %s OFFSET %s"
+            )
+            cursor.execute(query, tuple(params + [page_size, offset]))
             rows = cursor.fetchall()
             leaderboard = []
-            for i, row in enumerate(rows):
+            for i, row in enumerate(rows, start=offset):
+                details = {}
+                if row.get("evaluation_details"):
+                    try:
+                        details = json.loads(row["evaluation_details"]) if isinstance(row["evaluation_details"], str) else row["evaluation_details"]
+                    except Exception:
+                        details = {}
                 leaderboard.append({
                     "rank": i + 1,
                     "model_name": row['model_name'],
@@ -226,11 +368,19 @@ def get_leaderboard():
                     "task_type": row.get('task_type'),
                     "evaluation_metric": row.get('evaluation_metric'),
                     "score": float(row['score']),
+                    "submitted_by": row.get("submitted_by"),
+                    "metadata": details.get("metadata") if isinstance(details, dict) else None,
                     "submitted_at": row['submitted_at'].isoformat() if row.get('submitted_at') else None,
                 })
-            return jsonify({"success": True, "leaderboard": leaderboard})
+            return jsonify({
+                "success": True,
+                "leaderboard": leaderboard,
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+            })
         except Exception as e:
-            print(f"Error reading leaderboard from DB: {e}")
+            logger.exception("leaderboard_db_read_failed", extra={"error": str(e)})
         finally:
             try:
                 cursor.close()
@@ -239,12 +389,19 @@ def get_leaderboard():
                 pass
 
     # In-memory fallback
-    mem = sorted(_STORE["evaluations"], key=lambda x: x["score"], reverse=True)[:limit]
-    leaderboard = []
-    for i, ev in enumerate(mem):
+    mem_all = []
+    for ev in _STORE["evaluations"]:
         sub = next((s for s in _STORE["submissions"] if s["id"] == ev["submission_id"]), None)
         if not sub:
             continue
+        if dataset_filter and sub["benchmark_dataset_name"] != dataset_filter:
+            continue
+        mem_all.append((ev, sub))
+    mem_all.sort(key=lambda x: x[0]["score"], reverse=True)
+    total = len(mem_all)
+    mem = mem_all[offset:offset + page_size]
+    leaderboard = []
+    for i, (ev, sub) in enumerate(mem, start=offset):
         leaderboard.append({
             "rank": i + 1,
             "model_name": sub["model_name"],
@@ -252,12 +409,22 @@ def get_leaderboard():
             "task_type": "translation",
             "evaluation_metric": ev["metric"],
             "score": ev["score"],
+            "submitted_by": sub.get("submitted_by"),
+            "metadata": sub.get("metadata"),
             "submitted_at": sub["created"].isoformat(),
         })
-    return jsonify({"success": True, "leaderboard": leaderboard})
+    return jsonify({
+        "success": True,
+        "leaderboard": leaderboard,
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+    })
 
 
 @app.post('/public/submit_model')
+@rate_limit("SUBMIT_MODEL_RATE_LIMIT", "10/minute")
+@require_api_key
 def submit_model():
     """Submit model results to a benchmark dataset and compute evaluation.
 
@@ -270,12 +437,17 @@ def submit_model():
     }
     """
     data = request.get_json(silent=True) or {}
-    benchmark_dataset_name = data.get('benchmarkDatasetName')
-    model_name = data.get('modelName')
+    try:
+        benchmark_dataset_name = validate_text(data.get('benchmarkDatasetName'), "benchmarkDatasetName")
+        model_name = validate_text(data.get('modelName'), "modelName")
+        submitted_by = validate_text(data.get("submittedBy", "public@anote.ai"), "submittedBy", 255)
+        metadata = validate_metadata(data.get("metadata"))
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
     model_results = data.get('modelResults')
     sentence_ids = data.get('sentence_ids')
 
-    if not all([benchmark_dataset_name, model_name, isinstance(model_results, list), isinstance(sentence_ids, list)]):
+    if not all([isinstance(model_results, list), isinstance(sentence_ids, list)]):
         return jsonify({
             "success": False,
             "error": "Missing required fields: benchmarkDatasetName, modelName, modelResults (list), sentence_ids (list)",
@@ -299,7 +471,8 @@ def submit_model():
             dataset = cursor_meta.fetchone()
         finally:
             try:
-                cursor_meta.close(); conn_meta.close()
+                cursor_meta.close()
+                conn_meta.close()
             except Exception:
                 pass
 
@@ -351,9 +524,11 @@ def submit_model():
 
     def _f1_macro(y_true, y_pred):
         # Simple macro-F1 without external deps
-        from collections import Counter, defaultdict
+        from collections import Counter
         labels = set(map(str, y_true)) | set(map(str, y_pred))
-        tp = Counter(); fp = Counter(); fn = Counter();
+        tp = Counter()
+        fp = Counter()
+        fn = Counter()
         for t, p in zip(map(str, y_true), map(str, y_pred)):
             if t == p:
                 tp[t] += 1
@@ -371,7 +546,6 @@ def submit_model():
     # Helpers for NER (simple entity-string macro-F1)
     def _f1_entities(ref_lists, pred_lists):
         # Each element is a list of strings. Compute micro or macro? We'll do macro over examples.
-        import math
         if not ref_lists or not pred_lists or len(ref_lists) != len(pred_lists):
             return 0.0
         f1s = []
@@ -483,14 +657,14 @@ def submit_model():
             cursor.execute(
                 "INSERT INTO model_submissions (benchmark_dataset_id, model_name, submitted_by, model_results) "
                 "VALUES (%s, %s, %s, %s)",
-                (dataset_id, model_name, 'public@anote.ai', json.dumps(model_results))
+                (dataset_id, model_name, submitted_by, json.dumps(model_results))
             )
             submission_id = cursor.lastrowid
 
             cursor.execute(
                 "INSERT INTO evaluation_results (model_submission_id, score, evaluation_details) "
                 "VALUES (%s, %s, %s)",
-                (submission_id, float(score), json.dumps({"metric": metric}))
+                (submission_id, float(score), json.dumps({"metric": metric, "metadata": metadata}))
             )
             conn.commit()
         except Exception as e:
@@ -512,16 +686,22 @@ def submit_model():
             "id": submission_id,
             "benchmark_dataset_name": benchmark_dataset_name,
             "model_name": model_name,
+            "submitted_by": submitted_by,
+            "metadata": metadata,
             "results": model_results,
-            "created": datetime.utcnow(),
+            "created": utc_now(),
         })
         _STORE["evaluations"].append({
             "submission_id": submission_id,
             "score": float(score),
             "metric": metric,
-            "created": datetime.utcnow(),
+            "created": utc_now(),
         })
 
+    logger.info(
+        "model_submitted",
+        extra={"dataset": benchmark_dataset_name, "model": model_name, "score": float(score)},
+    )
     return jsonify({"success": True, "score": float(score)})
 
 
@@ -562,7 +742,8 @@ def list_public_datasets():
             return jsonify({"success": True, "datasets": items})
         finally:
             try:
-                cursor.close(); conn.close()
+                cursor.close()
+                conn.close()
             except Exception:
                 pass
     # Fallback if DB not configured: include curated in-memory datasets too
@@ -592,6 +773,8 @@ def list_public_datasets():
 
 
 @app.post('/public/add_dataset')
+@rate_limit("ADD_DATASET_RATE_LIMIT", "5/minute")
+@require_api_key
 def add_dataset_public():
     """Create a new benchmark dataset entry.
 
@@ -604,13 +787,13 @@ def add_dataset_public():
     }
     """
     data = request.get_json(silent=True) or {}
-    name = data.get('name')
-    task_type = data.get('task_type')
-    evaluation_metric = data.get('evaluation_metric')
+    try:
+        name = validate_text(data.get('name'), "name")
+        task_type = validate_text(data.get('task_type'), "task_type", 100)
+        evaluation_metric = validate_text(data.get('evaluation_metric'), "evaluation_metric", 100)
+    except ValueError as e:
+        return jsonify({"success": False, "error": str(e)}), 400
     reference_data = data.get('reference_data') or {}
-
-    if not all([name, task_type, evaluation_metric]):
-        return jsonify({"success": False, "error": "Missing required fields: name, task_type, evaluation_metric"}), 400
 
     if not isinstance(reference_data, (dict, list)):
         return jsonify({"success": False, "error": "reference_data must be JSON object or array"}), 400
@@ -635,6 +818,7 @@ def add_dataset_public():
             "url": reference_data.get('url') if isinstance(reference_data, dict) else None,
             "models": [],
         })
+        logger.info("dataset_added_memory", extra={"dataset": name, "task_type": task_type})
         return jsonify({"success": True, "message": "Dataset added (in-memory)"})
 
     try:
@@ -643,6 +827,7 @@ def add_dataset_public():
             (name, task_type, evaluation_metric, json.dumps(reference_data))
         )
         conn.commit()
+        logger.info("dataset_added", extra={"dataset": name, "task_type": task_type})
         return jsonify({"success": True, "message": "Dataset added"})
     except Exception as e:
         if 'Duplicate' in str(e) or 'UNIQUE' in str(e):
@@ -651,7 +836,8 @@ def add_dataset_public():
         return jsonify({"success": False, "error": "Failed to add dataset"}), 500
     finally:
         try:
-            cursor.close(); conn.close()
+            cursor.close()
+            conn.close()
         except Exception:
             pass
 
@@ -714,7 +900,8 @@ def dataset_details():
             })
         finally:
             try:
-                cursor.close(); conn.close()
+                cursor.close()
+                conn.close()
             except Exception:
                 pass
 
@@ -772,6 +959,8 @@ def list_task_metrics(task_type):
 
 
 @app.post('/public/import_hf_dataset')
+@rate_limit("IMPORT_DATASET_RATE_LIMIT", "5/minute")
+@require_api_key
 def import_hf_dataset_public():
     """Import a bounded Hugging Face dataset split into benchmark_datasets/reference_data."""
     data = request.get_json(silent=True) or {}
@@ -818,7 +1007,8 @@ def import_hf_dataset_public():
             return jsonify({"success": False, "error": "Failed to import dataset"}), 500
         finally:
             try:
-                cursor.close(); conn.close()
+                cursor.close()
+                conn.close()
             except Exception:
                 pass
     else:
@@ -846,22 +1036,88 @@ def import_hf_dataset_public():
     })
 
 
+@app.post('/api/datasets/ingest')
+@rate_limit("IMPORT_DATASET_RATE_LIMIT", "5/minute")
+@require_api_key
+def ingest_dataset():
+    """Issue-compatible ingestion endpoint for Hugging Face sources."""
+    data = request.get_json(silent=True) or {}
+    source = (data.get("source") or "").lower()
+    if source not in {"huggingface", "hf"}:
+        return jsonify({"success": False, "error": "Only source=huggingface is currently supported"}), 400
+    mapped = {
+        "dataset_name": data.get("dataset_id") or data.get("dataset_name"),
+        "config": data.get("config"),
+        "split": data.get("split", "test"),
+        "limit": data.get("max_samples", data.get("limit", 100)),
+        "task_type": data.get("task_type"),
+        "display_name": data.get("display_name"),
+        "preview_only": data.get("preview_only", False),
+    }
+    with app.test_request_context(
+        "/public/import_hf_dataset",
+        method="POST",
+        json=mapped,
+        headers=dict(request.headers),
+    ):
+        return import_hf_dataset_public()
+
+
+@app.get('/public/export/leaderboard')
+def export_leaderboard():
+    """Export leaderboard rows as CSV or JSON."""
+    dataset_name = request.args.get("dataset")
+    export_format = (request.args.get("format") or "csv").lower()
+    with app.test_request_context(
+        "/public/get_leaderboard",
+        query_string={
+            "dataset": dataset_name or "",
+            "page": "1",
+            "page_size": "100",
+        },
+    ):
+        payload = get_leaderboard().get_json()
+    rows = payload.get("leaderboard", []) if payload else []
+    if export_format == "json":
+        return jsonify({"success": True, "leaderboard": rows})
+    if export_format != "csv":
+        return jsonify({"success": False, "error": "format must be csv or json"}), 400
+
+    out = StringIO()
+    writer = csv.DictWriter(
+        out,
+        fieldnames=["rank", "dataset_name", "model_name", "submitted_by", "score", "evaluation_metric", "submitted_at"],
+    )
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field) for field in writer.fieldnames})
+    filename = f"leaderboard-{dataset_name or 'all'}.csv"
+    return Response(
+        out.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
 # ---------------------------
 # Leaderboard UI API (per README)
 # ---------------------------
 @app.post('/api/leaderboard/add_dataset')
+@rate_limit("ADD_DATASET_RATE_LIMIT", "5/minute")
+@require_api_key
 def add_dataset():
     data = request.get_json(silent=True) or {}
-    required = ["name", "task_type"]
-    missing = [k for k in required if k not in data]
-    if missing:
-        return jsonify({"status": "error", "message": f"Missing required fields: {', '.join(missing)}"}), 400
+    try:
+        name = validate_text(data.get("name"), "name")
+        task_type = validate_text(data.get("task_type"), "task_type", 100)
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
     dataset_id = str(uuid.uuid4())
     new_ds = {
         "id": dataset_id,
-        "name": data["name"],
+        "name": name,
         "url": data.get("url"),
-        "task_type": data["task_type"],
+        "task_type": task_type,
         "description": data.get("description"),
         "models": data.get("models", []),
     }
@@ -874,17 +1130,24 @@ def add_dataset():
 
 
 @app.post('/api/leaderboard/add_model')
+@rate_limit("SUBMIT_MODEL_RATE_LIMIT", "10/minute")
+@require_api_key
 def add_model():
     data = request.get_json(silent=True) or {}
-    required = ["dataset_name", "model", "rank", "score", "updated"]
+    required = ["rank", "score", "updated"]
     missing = [k for k in required if k not in data]
     if missing:
         return jsonify({"status": "error", "message": f"Missing required fields: {', '.join(missing)}"}), 400
+    try:
+        dataset_name = validate_text(data.get("dataset_name"), "dataset_name")
+        model = validate_text(data.get("model"), "model")
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
     for ds in LEADERBOARD_DATA:
-        if ds.get("name") == data["dataset_name"]:
+        if ds.get("name") == dataset_name:
             ds.setdefault("models", []).append({
                 "rank": data["rank"],
-                "model": data["model"],
+                "model": model,
                 "score": data["score"],
                 "ci": data.get("ci"),
                 "updated": data["updated"],
@@ -941,6 +1204,8 @@ def list_benchmark_models():
 
 
 @app.post('/public/run_csv_benchmarks')
+@rate_limit("RUN_CSV_RATE_LIMIT", "5/minute")
+@require_api_key
 def run_csv_benchmarks():
     """Run evaluations over CSV datasets using provided model configs.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -958,6 +958,35 @@ def list_task_metrics(task_type):
     return jsonify({"success": True, "task_type": task_type, "metrics": metrics_for_task(task_type)})
 
 
+@app.get('/openapi.json')
+def openapi_spec():
+    """Small OpenAPI document for public integration endpoints."""
+    return jsonify({
+        "openapi": "3.0.3",
+        "info": {"title": "Anote Leaderboard API", "version": "0.2.0"},
+        "paths": {
+            "/public/datasets": {"get": {"summary": "List public datasets"}},
+            "/public/add_dataset": {"post": {"summary": "Create a public dataset"}},
+            "/public/import_hf_dataset": {"post": {"summary": "Import a Hugging Face dataset split"}},
+            "/api/datasets/ingest": {"post": {"summary": "Ingest a dataset from a configured source"}},
+            "/public/submit_model": {"post": {"summary": "Submit model outputs for evaluation"}},
+            "/public/get_leaderboard": {
+                "get": {
+                    "summary": "Get leaderboard rows",
+                    "parameters": [
+                        {"name": "dataset", "in": "query", "schema": {"type": "string"}},
+                        {"name": "page", "in": "query", "schema": {"type": "integer", "default": 1}},
+                        {"name": "page_size", "in": "query", "schema": {"type": "integer", "default": 25}},
+                    ],
+                }
+            },
+            "/public/export/leaderboard": {"get": {"summary": "Export leaderboard rows as CSV or JSON"}},
+            "/api/metrics": {"get": {"summary": "List metric metadata"}},
+            "/api/metrics/task/{task_type}": {"get": {"summary": "List metrics for a task type"}},
+        },
+    })
+
+
 @app.post('/public/import_hf_dataset')
 @rate_limit("IMPORT_DATASET_RATE_LIMIT", "5/minute")
 @require_api_key

--- a/backend/hf_importer.py
+++ b/backend/hf_importer.py
@@ -15,6 +15,7 @@ TASK_DEFAULTS = {
     "document_qa": {"primary_metric": "exact", "answer_keys": ["answers", "answer"]},
     "line_qa": {"primary_metric": "exact", "answer_keys": ["answers", "answer"]},
     "translation": {"primary_metric": "bleu", "answer_keys": ["translation", "target", "answer"]},
+    "named_entity_recognition": {"primary_metric": "f1", "answer_keys": ["entities", "ner_tags", "answer"]},
 }
 
 KNOWN_DATASETS = {
@@ -23,6 +24,12 @@ KNOWN_DATASETS = {
     "nyu-mll/glue": "text_classification",
     "squad": "document_qa",
     "rajpurkar/squad": "document_qa",
+}
+
+TASK_ALIASES = {
+    "classification": "text_classification",
+    "qa": "document_qa",
+    "ner": "named_entity_recognition",
 }
 
 
@@ -48,8 +55,17 @@ def _load_dataset(dataset_name: str, config: Optional[str], split: str):
 
 def infer_task_type(dataset_name: str, requested_task_type: Optional[str] = None) -> str:
     if requested_task_type:
-        return requested_task_type
+        return TASK_ALIASES.get(requested_task_type, requested_task_type)
     return KNOWN_DATASETS.get(dataset_name, "text_classification")
+
+
+def _label_names(ds) -> Optional[List[str]]:
+    try:
+        feature = ds.features.get("label")
+        names = getattr(feature, "names", None)
+        return list(names) if names else None
+    except Exception:
+        return None
 
 
 def _first_present(row: Dict[str, Any], keys: List[str]) -> Any:
@@ -59,8 +75,10 @@ def _first_present(row: Dict[str, Any], keys: List[str]) -> Any:
     return None
 
 
-def _answer_from_row(row: Dict[str, Any], task_type: str) -> Any:
+def _answer_from_row(row: Dict[str, Any], task_type: str, label_names: Optional[List[str]] = None) -> Any:
     answer = _first_present(row, TASK_DEFAULTS.get(task_type, TASK_DEFAULTS["text_classification"])["answer_keys"])
+    if isinstance(answer, int) and label_names and 0 <= answer < len(label_names):
+        return label_names[answer]
     if isinstance(answer, dict) and isinstance(answer.get("text"), list):
         return answer["text"][0] if len(answer["text"]) == 1 else answer["text"]
     if isinstance(answer, dict):
@@ -95,6 +113,7 @@ def import_hf_dataset(
     metric = TASK_DEFAULTS.get(resolved_task_type, TASK_DEFAULTS["text_classification"])["primary_metric"]
     ds = _load_dataset(dataset_name, config, split)
     count = min(limit, len(ds))
+    label_names = _label_names(ds)
 
     source_texts = []
     answers = []
@@ -103,7 +122,7 @@ def import_hf_dataset(
     for idx in range(count):
         row = dict(ds[idx])
         question = _question_from_row(row)
-        answer = _answer_from_row(row, resolved_task_type)
+        answer = _answer_from_row(row, resolved_task_type, label_names)
         source_texts.append(question)
         if resolved_task_type == "text_classification":
             labels.append(str(answer))
@@ -119,6 +138,7 @@ def import_hf_dataset(
         "hf_dataset": dataset_name,
         "hf_config": config,
         "hf_split": split,
+        "label_names": label_names,
     }
     if labels:
         reference_data["labels"] = labels

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,6 +28,16 @@ def _getenv(name: str) -> str | None:
     return v if v and v.strip() else None
 
 
+def _trust_remote_code_for(model_name: str) -> bool:
+    """Remote code execution is opt-in by exact model id."""
+    allowlist = {
+        item.strip()
+        for item in os.getenv("TRUSTED_REMOTE_CODE_MODELS", "").split(",")
+        if item.strip()
+    }
+    return model_name in allowlist
+
+
 def zero_shot_gpt4o(prompt: str) -> str:
     try:
         from openai import OpenAI  # type: ignore
@@ -114,7 +124,7 @@ def zero_shot_llama3(prompt: str) -> str:
         model_name,
         torch_dtype=torch.bfloat16,
         device_map="auto",
-        trust_remote_code=True,
+        trust_remote_code=_trust_remote_code_for(model_name),
     )
     pipe = pipeline(
         "text-generation",
@@ -140,7 +150,7 @@ def zero_shot_mistral(prompt: str) -> str:
         model_name,
         torch_dtype=torch.bfloat16,
         device_map="auto",
-        trust_remote_code=True,
+        trust_remote_code=_trust_remote_code_for(model_name),
     )
     pipe = pipeline(
         "text-generation",
@@ -198,4 +208,3 @@ def list_models() -> List[Dict[str, str]]:
 
 def get_model_functions() -> Dict[str, Callable[[str], str]]:
     return {name: globals()[name] for name in globals() if name.startswith("zero_shot_") and callable(globals()[name])}
-

--- a/backend/pytest/test_data/test_leaderboard_api.py
+++ b/backend/pytest/test_data/test_leaderboard_api.py
@@ -5,7 +5,6 @@ Tests the core leaderboard functionality: submit models, get rankings, get test 
 """
 
 import requests
-import json
 import os
 import pytest
 
@@ -33,7 +32,7 @@ def check_api_available():
         api_url = get_api_base_url()
         response = requests.get(f"{api_url}/health", timeout=5)
         return response.status_code == 200
-    except:
+    except Exception:
         return False
 
 # Skip all tests if API is not available

--- a/backend/pytest/test_dataset_endpoints.py
+++ b/backend/pytest/test_dataset_endpoints.py
@@ -1,7 +1,6 @@
-import json
 import pytest
 
-from backend.app import app, LEADERBOARD_DATA, _STORE
+from backend.app import _RATE_WINDOWS, app, LEADERBOARD_DATA, _STORE
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +10,7 @@ def _clean_state():
     _STORE['submissions'].clear()
     _STORE['evaluations'].clear()
     _STORE['datasets'].clear()
+    _RATE_WINDOWS.clear()
     yield
 
 
@@ -33,6 +33,7 @@ def test_add_and_list_public_datasets():
     assert res.status_code in (200, 201)
     data = res.get_json()
     assert data["success"] is True
+    assert data["ok"] is True
 
     # List
     res = client.get('/public/datasets')
@@ -155,3 +156,61 @@ def test_in_memory_dataset_reference_data_scores_classification():
     data = res.get_json()
     assert data["success"] is True
     assert data["score"] == 0.5
+
+
+def test_submit_validation_rejects_blank_model_name():
+    client = app.test_client()
+
+    res = client.post('/public/submit_model', json={
+        "benchmarkDatasetName": "flores_spanish_translation",
+        "modelName": " ",
+        "modelResults": ["x"],
+        "sentence_ids": [0]
+    })
+
+    assert res.status_code == 400
+    assert res.get_json()["success"] is False
+
+
+def test_leaderboard_pagination_metadata_and_export():
+    client = app.test_client()
+    client.post('/public/submit_model', json={
+        "benchmarkDatasetName": "flores_spanish_translation",
+        "modelName": "meta-model",
+        "modelResults": ["Este es un ejemplo de oración para evaluación."],
+        "sentence_ids": [0],
+        "metadata": {"model_version": "1.0"}
+    })
+
+    res = client.get('/public/get_leaderboard?page=1&page_size=1')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["success"] is True
+    assert data["page"] == 1
+    assert data["page_size"] == 1
+    assert data["total"] == 1
+    assert data["leaderboard"][0]["metadata"]["model_version"] == "1.0"
+
+    res = client.get('/public/export/leaderboard?format=csv')
+    assert res.status_code == 200
+    assert res.mimetype == "text/csv"
+    assert "meta-model" in res.get_data(as_text=True)
+
+
+def test_api_key_required_when_configured(monkeypatch):
+    monkeypatch.setenv("LEADERBOARD_API_KEYS", "secret")
+    client = app.test_client()
+
+    res = client.post('/public/add_dataset', json={
+        "name": "blocked",
+        "task_type": "text_classification",
+        "evaluation_metric": "accuracy",
+    })
+    assert res.status_code == 401
+
+    res = client.post('/public/add_dataset', headers={"X-API-Key": "secret"}, json={
+        "name": "allowed",
+        "task_type": "text_classification",
+        "evaluation_metric": "accuracy",
+    })
+    assert res.status_code == 200

--- a/backend/pytest/test_dataset_endpoints.py
+++ b/backend/pytest/test_dataset_endpoints.py
@@ -129,6 +129,11 @@ def test_metrics_catalog_endpoints():
     assert data["success"] is True
     assert "accuracy" in data["metrics"]
 
+    res = client.get('/openapi.json')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["openapi"].startswith("3.")
+
     res = client.get('/api/metrics/task/text_classification')
     assert res.status_code == 200
     data = res.get_json()

--- a/backend/pytest/test_sdk_client.py
+++ b/backend/pytest/test_sdk_client.py
@@ -1,7 +1,3 @@
-import json
-import types
-import pytest
-
 from backend.sdk.leaderboard_sdk import LeaderboardClient
 
 
@@ -21,7 +17,7 @@ class _Resp:
 def test_sdk_add_dataset(monkeypatch):
     calls = {}
 
-    def fake_request(method, url, json=None, timeout=None):
+    def fake_request(method, url, json=None, headers=None, timeout=None):
         calls['method'] = method
         calls['url'] = url
         calls['json'] = json
@@ -47,7 +43,7 @@ def test_sdk_add_dataset(monkeypatch):
 
 
 def test_sdk_list_public_datasets(monkeypatch):
-    def fake_request(method, url, json=None, timeout=None):
+    def fake_request(method, url, json=None, headers=None, timeout=None):
         return _Resp(200, {"success": True, "datasets": [{"name": "flores_spanish_translation", "task_type": "translation", "evaluation_metric": "bleu"}]})
 
     import requests
@@ -61,7 +57,7 @@ def test_sdk_list_public_datasets(monkeypatch):
 
 
 def test_sdk_submit_model(monkeypatch):
-    def fake_request(method, url, json=None, timeout=None):
+    def fake_request(method, url, json=None, headers=None, timeout=None):
         assert json["benchmarkDatasetName"] == "flores_spanish_translation"
         assert json["modelName"] == "my-model"
         assert isinstance(json["modelResults"], list)
@@ -80,4 +76,3 @@ def test_sdk_submit_model(monkeypatch):
     )
     assert res["success"] is True
     assert 0 <= res["score"] <= 1
-

--- a/backend/sdk/leaderboard_sdk.py
+++ b/backend/sdk/leaderboard_sdk.py
@@ -16,22 +16,27 @@ from typing import Any, Dict, Optional
 
 
 class LeaderboardClient:
-    def __init__(self, base_url: Optional[str] = None, timeout: int = 20):
+    def __init__(self, base_url: Optional[str] = None, timeout: int = 20, api_key: Optional[str] = None):
         self.base_url = base_url or os.getenv("LEADERBOARD_API_BASE", "http://localhost:5001")
         self.timeout = timeout
+        self.api_key = api_key or os.getenv("LEADERBOARD_API_KEY")
 
     def _request(self, method: str, path: str, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         url = f"{self.base_url}{path}"
-        r = requests.request(method, url, json=json, timeout=self.timeout)
+        headers = {"X-API-Key": self.api_key} if self.api_key else None
+        r = requests.request(method, url, json=json, headers=headers, timeout=self.timeout)
         r.raise_for_status()
         return r.json()
 
     # Curated leaderboard
     def add_dataset(self, name: str, task_type: str, url: Optional[str] = None, description: Optional[str] = None, models: Optional[list] = None) -> Dict[str, Any]:
         payload = {"name": name, "task_type": task_type}
-        if url: payload["url"] = url
-        if description: payload["description"] = description
-        if models: payload["models"] = models
+        if url:
+            payload["url"] = url
+        if description:
+            payload["description"] = description
+        if models:
+            payload["models"] = models
         return self._request("POST", "/api/leaderboard/add_dataset", json=payload)
 
     def add_model(self, dataset_name: str, model: str, rank: Optional[int], score: Optional[float], updated: str, ci: Optional[str] = None) -> Dict[str, Any]:
@@ -54,22 +59,48 @@ class LeaderboardClient:
         return self._request("POST", "/public/add_dataset", json=payload)
 
     # Evaluation endpoints (optional)
-    def get_leaderboard(self) -> Dict[str, Any]:
-        return self._request("GET", "/public/get_leaderboard")
+    def get_leaderboard(self, dataset: Optional[str] = None, page: int = 1, page_size: int = 25) -> Dict[str, Any]:
+        import urllib.parse as _u
+
+        params = {"page": page, "page_size": page_size}
+        if dataset:
+            params["dataset"] = dataset
+        return self._request("GET", f"/public/get_leaderboard?{_u.urlencode(params)}")
 
     def get_source_sentences(self, dataset_name: str = "flores_spanish_translation", count: int = 3, start_idx: int = 0) -> Dict[str, Any]:
         import urllib.parse as _u
         qs = _u.urlencode({"dataset_name": dataset_name, "count": count, "start_idx": start_idx})
         return self._request("GET", f"/public/get_source_sentences?{qs}")
 
-    def submit_model(self, benchmark_dataset_name: str, model_name: str, model_results: list[str], sentence_ids: list[int]) -> Dict[str, Any]:
+    def submit_model(
+        self,
+        benchmark_dataset_name: str,
+        model_name: str,
+        model_results: list[str],
+        sentence_ids: list[int],
+        metadata: Optional[dict] = None,
+    ) -> Dict[str, Any]:
         payload = {
             "benchmarkDatasetName": benchmark_dataset_name,
             "modelName": model_name,
             "modelResults": model_results,
             "sentence_ids": sentence_ids,
         }
+        if metadata:
+            payload["metadata"] = metadata
         return self._request("POST", "/public/submit_model", json=payload)
+
+    def import_hf_dataset(self, dataset_name: str, split: str = "test", limit: int = 100, **kwargs) -> Dict[str, Any]:
+        payload = {"dataset_name": dataset_name, "split": split, "limit": limit, **kwargs}
+        return self._request("POST", "/public/import_hf_dataset", json=payload)
+
+    def export_leaderboard(self, dataset: Optional[str] = None, format: str = "json") -> Dict[str, Any]:
+        import urllib.parse as _u
+
+        params = {"format": format}
+        if dataset:
+            params["dataset"] = dataset
+        return self._request("GET", f"/public/export/leaderboard?{_u.urlencode(params)}")
 
     # CSV benchmarks
     def list_benchmark_csvs(self) -> Dict[str, Any]:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: agents
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./backend/database/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+
+  backend:
+    build: ./backend
+    environment:
+      PORT: 5001
+      FLASK_ENV: development
+      ALLOWED_ORIGINS: http://localhost:3000,http://127.0.0.1:3000
+      DB_HOST: db
+      DB_USER: root
+      DB_PASSWORD: root
+      DB_NAME: agents
+      DB_PORT: 3306
+    ports:
+      - "5001:5001"
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    environment:
+      REACT_APP_API_BASE: http://localhost:5001
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,20 @@ curl http://localhost:5001/public/datasets
 curl "http://localhost:5001/public/dataset_details?name=flores_spanish_translation"
 ```
 
+## Authentication
+
+Read endpoints are public. Write and evaluation endpoints can be protected by setting:
+
+```bash
+export LEADERBOARD_API_KEYS=secret-key-1,secret-key-2
+```
+
+When keys are configured, send one with each write request:
+
+```bash
+curl -H "X-API-Key: secret-key-1" ...
+```
+
 ## Metric Metadata
 
 ```bash
@@ -39,12 +53,26 @@ curl -X POST http://localhost:5001/public/submit_model \
     "benchmarkDatasetName": "demo_classification",
     "modelName": "my-model",
     "modelResults": ["positive", "negative"],
-    "sentence_ids": [0, 1]
+    "sentence_ids": [0, 1],
+    "metadata": {
+      "model_version": "1.0",
+      "paper_url": "https://example.com/paper"
+    }
   }'
 ```
 
 ## View Leaderboard
 
 ```bash
-curl http://localhost:5001/public/get_leaderboard
+curl "http://localhost:5001/public/get_leaderboard?page=1&page_size=25"
+curl "http://localhost:5001/public/get_leaderboard?dataset=demo_classification&page=1&page_size=25"
+```
+
+The response includes `page`, `page_size`, and `total`.
+
+## Export Leaderboard
+
+```bash
+curl "http://localhost:5001/public/export/leaderboard?format=json"
+curl "http://localhost:5001/public/export/leaderboard?dataset=demo_classification&format=csv"
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,7 @@ curl -H "X-API-Key: secret-key-1" ...
 ```bash
 curl http://localhost:5001/api/metrics
 curl http://localhost:5001/api/metrics/task/text_classification
+curl http://localhost:5001/openapi.json
 ```
 
 ## Add a Dataset

--- a/docs/huggingface-imports.md
+++ b/docs/huggingface-imports.md
@@ -34,6 +34,20 @@ curl -X POST http://localhost:5001/public/import_hf_dataset \
   }'
 ```
 
+The ingestion-compatible alias is also available:
+
+```bash
+curl -X POST http://localhost:5001/api/datasets/ingest \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "huggingface",
+    "dataset_id": "ag_news",
+    "split": "test",
+    "max_samples": 100,
+    "task_type": "text_classification"
+  }'
+```
+
 When MySQL is configured, imported datasets are written to `benchmark_datasets`. Without MySQL, they live in the Flask in-memory store until the process restarts.
 
 ## Supported Conversion Defaults
@@ -41,3 +55,5 @@ When MySQL is configured, imported datasets are written to `benchmark_datasets`.
 - `text_classification`: stores `source_texts` and `labels`; default metric is `accuracy`.
 - `document_qa` and `line_qa`: stores `source_texts` and `answers`; default metric is `exact`.
 - `translation`: stores `source_texts` and `answers`; default metric is `bleu`.
+
+For Hugging Face datasets that expose class names in feature metadata, numeric labels are converted to readable labels during import.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,7 +4,7 @@
 
 Local development works without a database. The API stores custom datasets, imported datasets, submissions, and evaluations in memory.
 
-For persistence, configure MySQL environment variables and load `backend/database/schema.sql`:
+For persistence, configure MySQL environment variables and load `backend/database/schema.sql`. The compose setup mounts that schema directly into MySQL initialization:
 
 ```bash
 export DB_HOST=localhost
@@ -13,6 +13,8 @@ export DB_PASSWORD=
 export DB_NAME=agents
 export DB_PORT=3306
 ```
+
+The Personal repo's richer SQLAlchemy schema uses `datasets`, `submissions`, and `leaderboard_entries`. This Flask app keeps its existing MySQL table names for compatibility, while the import/evaluation payload shapes now match the Personal implementation closely enough to migrate later without changing clients.
 
 ## Configuration
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,8 +17,14 @@ export DB_PORT=3306
 ## Configuration
 
 - `PORT`: Flask port. Use `5001` for the current frontend default.
-- `ALLOWED_ORIGINS`: comma-separated CORS origins. Defaults to `*` for local development.
+- `ALLOWED_ORIGINS`: comma-separated CORS origins. Development defaults to local React origins. Non-development environments must set this explicitly.
 - `REACT_APP_API_BASE`: frontend API base URL.
+- `REACT_APP_GA_ID`: optional Google Analytics measurement id. Leave unset in local development.
+- `LEADERBOARD_API_KEYS`: comma-separated API keys for write endpoints. If unset, writes stay open for local development.
+- `REQUIRE_API_KEY`: set to `true` to require `X-API-Key` even if keys are injected later by deployment config.
+- `SUBMIT_MODEL_RATE_LIMIT`, `ADD_DATASET_RATE_LIMIT`, `IMPORT_DATASET_RATE_LIMIT`, `RUN_CSV_RATE_LIMIT`: per-IP limits such as `10/minute`.
+- `DISABLE_RATE_LIMIT`: set to `1` for trusted local test runs.
+- `TRUSTED_REMOTE_CODE_MODELS`: comma-separated Hugging Face model ids allowed to use `trust_remote_code`.
 
 ## Remaining Known Gaps
 

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -33,6 +33,14 @@ REACT_APP_API_BASE=http://localhost:5001 npm start
 
 Open `http://localhost:3000`.
 
+## Docker Compose
+
+```bash
+docker compose up --build
+```
+
+This starts MySQL, the Flask backend on `http://localhost:5001`, and the React frontend on `http://localhost:3000`.
+
 ## Docs
 
 ```bash

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ENV HOST=0.0.0.0
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --legacy-peer-deps
 
 COPY . .
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "lint": "eslint src --ext .js,.jsx",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,28 +1,37 @@
 import LandingPage from "./landing_page/LandingPage";
+import ErrorBoundary from "./ErrorBoundary";
 import ReactGA4 from "react-ga4";
 import { BrowserRouter as Router, useLocation } from "react-router-dom";
 import { useEffect } from "react";
-ReactGA4.initialize("G-CMN1GX5JE1");
+
+const GA_ID = process.env.REACT_APP_GA_ID;
+if (GA_ID) {
+  ReactGA4.initialize(GA_ID);
+}
 
 function PageTracker({subdomain}) {
   let location = useLocation();
 
   useEffect(() => {
-    ReactGA4.send({
-      hitType: 'pageview',
-      page: subdomain + "/" + location.pathname,
-    });
-  }, [location]);
+    if (GA_ID) {
+      ReactGA4.send({
+        hitType: 'pageview',
+        page: subdomain + "/" + location.pathname,
+      });
+    }
+  }, [location, subdomain]);
 
   return null; // This component does not render anything
 }
 
 function App() {
   return (
-    <Router>
-      <PageTracker subdomain="landingpage" />
-      <LandingPage />
-    </Router>
+    <ErrorBoundary>
+      <Router>
+        <PageTracker subdomain="landingpage" />
+        <LandingPage />
+      </Router>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/src/ErrorBoundary.js
+++ b/frontend/src/ErrorBoundary.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    // Keep this local; production telemetry can hook in here later.
+    console.error("App render error", error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center px-6 text-center">
+          <h1 className="text-2xl font-semibold text-[#EDDC8F]">Something went wrong.</h1>
+          <button
+            className="mt-4 px-4 py-2 rounded-md border border-gray-700 hover:bg-gray-800"
+            onClick={() => this.setState({ error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/constants/RouteConstants.js
+++ b/frontend/src/constants/RouteConstants.js
@@ -3,3 +3,4 @@ export const submittoleaderboardPath = "/submit";
 export const adminLeaderboardPath = "/leaderboard/admin";
 export const evaluationsPath = "/evaluations";
 export const csvBenchmarksPath = "/benchmarks";
+export const addDatasetPath = "/datasets/new";

--- a/frontend/src/landing_page/LandingPage.js
+++ b/frontend/src/landing_page/LandingPage.js
@@ -17,8 +17,9 @@ import Leaderboard from "./landing_page_components/Leaderboard";
 import SubmitToLeaderboard  from "./landing_page_components/SubmitToLeaderboard";
 import Evaluations  from "./landing_page_components/Evaluations"
 import AdminLeaderboardManager from "./landing_page_components/AdminLeaderboardManager";
+import AddDataset from "./landing_page_components/AddDataset";
 import DatasetDetails from "./landing_page_components/DatasetDetails";
-import { submittoleaderboardPath, adminLeaderboardPath, evaluationsPath, csvBenchmarksPath } from "../constants/RouteConstants";
+import { submittoleaderboardPath, adminLeaderboardPath, evaluationsPath, csvBenchmarksPath, addDatasetPath } from "../constants/RouteConstants";
 import HeaderBar from "./landing_page_components/HeaderBar";
 import CsvBenchmarksDemo from "./landing_page_components/CsvBenchmarksDemo";
 
@@ -68,6 +69,7 @@ function LandingPage() {
           <Route path={submittoleaderboardPath} index element={<SubmitToLeaderboard />} />,
           <Route path={evaluationsPath} index element={<Evaluations />} />,
           <Route path={csvBenchmarksPath} index element={<CsvBenchmarksDemo />} />,
+          <Route path={addDatasetPath} index element={<AddDataset />} />,
           <Route path="/dataset/:name" element={<DatasetDetails />} />,
           <Route path={adminLeaderboardPath} index element={<AdminLeaderboardManager />} />,
           <Route path="*" element={<Navigate replace to="/" />} />

--- a/frontend/src/landing_page/landing_page_components/AddDataset.js
+++ b/frontend/src/landing_page/landing_page_components/AddDataset.js
@@ -1,0 +1,212 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import LeaderboardSDK from "../../lib/leaderboardSdk";
+import { evaluationsPath } from "../../constants/RouteConstants";
+
+const emptyForm = {
+  source: "manual",
+  name: "",
+  task_type: "text_classification",
+  evaluation_metric: "accuracy",
+  description: "",
+  url: "",
+  hf_dataset: "",
+  hf_config: "",
+  hf_split: "test",
+  hf_limit: 100,
+};
+
+const AddDataset = () => {
+  const [form, setForm] = useState(emptyForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  const update = (key, value) => setForm((current) => ({ ...current, [key]: value }));
+
+  const submit = async (event) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setMessage("");
+    setError("");
+    try {
+      if (form.source === "huggingface") {
+        const result = await LeaderboardSDK.importHfDataset({
+          dataset_name: form.hf_dataset,
+          config: form.hf_config || undefined,
+          split: form.hf_split,
+          limit: Number(form.hf_limit) || 100,
+          task_type: form.task_type,
+          display_name: form.name || undefined,
+        });
+        setMessage(`Imported ${result.dataset?.name || form.hf_dataset}`);
+      } else {
+        await LeaderboardSDK.addDatasetPublic({
+          name: form.name,
+          task_type: form.task_type,
+          evaluation_metric: form.evaluation_metric,
+          reference_data: {
+            description: form.description || undefined,
+            url: form.url || undefined,
+            source_texts: [],
+          },
+        });
+        setMessage(`Created ${form.name}`);
+      }
+      setForm(emptyForm);
+    } catch (err) {
+      setError(err.message || "Failed to create dataset");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="bg-black min-h-screen py-10 px-4 text-gray-100">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-between gap-4 mb-6">
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-[#EDDC8F]">Add Dataset</h1>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-900"
+            onClick={() => navigate(evaluationsPath)}
+          >
+            View Leaderboard
+          </button>
+        </div>
+
+        <form onSubmit={submit} className="border border-gray-800 rounded-lg bg-gray-950 p-5 space-y-4">
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Source</label>
+            <select
+              className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+              value={form.source}
+              onChange={(event) => update("source", event.target.value)}
+            >
+              <option value="manual">Manual</option>
+              <option value="huggingface">Hugging Face</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">Display Name</label>
+              <input
+                className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                value={form.name}
+                onChange={(event) => update("name", event.target.value)}
+                required={form.source === "manual"}
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">Task Type</label>
+              <select
+                className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                value={form.task_type}
+                onChange={(event) => update("task_type", event.target.value)}
+              >
+                <option value="text_classification">Text Classification</option>
+                <option value="translation">Translation</option>
+                <option value="document_qa">Document QA</option>
+                <option value="line_qa">Line QA</option>
+                <option value="named_entity_recognition">Named Entity Recognition</option>
+              </select>
+            </div>
+          </div>
+
+          {form.source === "huggingface" ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Dataset ID</label>
+                <input
+                  placeholder="ag_news"
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.hf_dataset}
+                  onChange={(event) => update("hf_dataset", event.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Config</label>
+                <input
+                  placeholder="optional"
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.hf_config}
+                  onChange={(event) => update("hf_config", event.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Split</label>
+                <input
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.hf_split}
+                  onChange={(event) => update("hf_split", event.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Max Samples</label>
+                <input
+                  type="number"
+                  min="1"
+                  max="5000"
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.hf_limit}
+                  onChange={(event) => update("hf_limit", event.target.value)}
+                  required
+                />
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Evaluation Metric</label>
+                <select
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.evaluation_metric}
+                  onChange={(event) => update("evaluation_metric", event.target.value)}
+                >
+                  <option value="accuracy">Accuracy</option>
+                  <option value="f1">F1</option>
+                  <option value="bleu">BLEU</option>
+                  <option value="bertscore">BERTScore</option>
+                  <option value="exact">Exact Match</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Dataset URL</label>
+                <input
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.url}
+                  onChange={(event) => update("url", event.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm text-gray-300 mb-1">Description</label>
+                <textarea
+                  className="w-full px-3 py-2 rounded-md bg-gray-900 border border-gray-700 text-white"
+                  value={form.description}
+                  onChange={(event) => update("description", event.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          {error ? <div className="text-sm text-red-400">{error}</div> : null}
+          {message ? <div className="text-sm text-green-400">{message}</div> : null}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-5 py-2 rounded-md border border-[#EDDC8F] text-[#EDDC8F] hover:bg-[#EDDC8F] hover:text-black disabled:opacity-50"
+          >
+            {submitting ? "Saving..." : "Save Dataset"}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+};
+
+export default AddDataset;

--- a/frontend/src/landing_page/landing_page_components/Evaluations.js
+++ b/frontend/src/landing_page/landing_page_components/Evaluations.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
-import { submittoleaderboardPath } from "../../constants/RouteConstants";
+import { addDatasetPath, submittoleaderboardPath } from "../../constants/RouteConstants";
 
 const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || process.env.REACT_APP_BACK_END_HOST || "http://localhost:5001";
 
@@ -107,12 +107,20 @@ const Evaluations = () => {
           Evaluation Leaderboard
         </h1>
 
-        <button
-          className="btn-black px-6 py-2 border border-yellow rounded hover:bg-white hover:text-white transition mb-6"
-          onClick={handleSubmitToLeaderboard}
-        >
-        Submit Model to Leaderboard
-        </button>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-6">
+          <button
+            className="btn-black px-6 py-2 border border-yellow rounded hover:bg-white hover:text-white transition"
+            onClick={handleSubmitToLeaderboard}
+          >
+          Submit Model to Leaderboard
+          </button>
+          <button
+            className="px-6 py-2 border border-gray-700 rounded text-gray-200 hover:bg-gray-900 transition"
+            onClick={() => navigate(addDatasetPath)}
+          >
+            Add Dataset
+          </button>
+        </div>
         <div className="max-w-xl mx-auto mt-2">
           <input
             type="text"

--- a/frontend/src/landing_page/landing_page_styles/LandingPage.css
+++ b/frontend/src/landing_page/landing_page_styles/LandingPage.css
@@ -1196,8 +1196,6 @@ import MetricsRoutes from "./metrics_components/MetricsRoutes";
 import ReactGA4 from 'react-ga4';
 import { BrowserRouter as Router } from "react-router-dom";
 
-ReactGA4.initialize("G-PNX85JC0CV");
-
 function App() {
   var isDashboardSubdomain = IsDashboardSubdomain();
   var isMetricsSubdomain = IsMetricsSubdomain();

--- a/frontend/src/lib/leaderboardSdk.js
+++ b/frontend/src/lib/leaderboardSdk.js
@@ -2,9 +2,13 @@
 const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
 
 async function http(method, path, body) {
+  const apiKey = process.env.REACT_APP_LEADERBOARD_API_KEY;
   const res = await fetch(`${API_BASE}${path}`, {
     method,
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { 'X-API-Key': apiKey } : {}),
+    },
     body: body ? JSON.stringify(body) : undefined,
   });
   const data = await res.json().catch(() => ({}));
@@ -21,6 +25,7 @@ export const LeaderboardSDK = {
   listDatasets: () => http('GET', '/api/leaderboard/list'),
   listPublicDatasets: () => http('GET', '/public/datasets'),
   addDatasetPublic: (payload) => http('POST', '/public/add_dataset', payload),
+  importHfDataset: (payload) => http('POST', '/public/import_hf_dataset', payload),
   getLeaderboard: () => http('GET', '/public/get_leaderboard'),
   listBenchmarkCsvs: () => http('GET', '/public/benchmark_csvs'),
   listBenchmarkModels: () => http('GET', '/public/benchmark_models'),

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,35 @@
 site_name: Anote Leaderboard
 site_description: Local and API documentation for the Anote model leaderboard.
+site_url: https://leaderboard.anote.ai/docs
+docs_dir: docs
+site_dir: site
+use_directory_urls: false
+repo_url: https://github.com/anote-ai/Leaderboard
+
 theme:
   name: material
   features:
-    - navigation.sections
-    - navigation.instant
+    - search.suggest
+    - search.highlight
+    - content.tabs.link
     - content.code.copy
+    - content.code.annotation
+    - navigation.instant
+    - navigation.sections
+  language: en
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+      primary: black
+      accent: light blue
+    - scheme: slate
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+      primary: black
+      accent: lime
 nav:
   - Home: index.md
   - Running Locally: running-locally.md
@@ -13,6 +37,23 @@ nav:
   - Hugging Face Imports: huggingface-imports.md
   - Operations: operations.md
 markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
   - admonition
+  - footnotes
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.mark
+  - attr_list
+  - tables
+
+plugins:
+  - search
+
+extra:
+  homepage: https://anote.ai
+  social:
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/anote-ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 200
+exclude = [
+  "frontend",
+  "site",
+]
+
+[tool.ruff.lint]
+select = ["E", "F"]


### PR DESCRIPTION
## Summary
- incorporates relevant open PR fixes directly: timezone-aware UTC, safe CORS defaults, GA env config, HF remote-code allowlist, and response envelope compatibility
- adds API-key-gated writes, in-process rate limits, input validation, submission metadata, structured logs, pagination, CSV/JSON exports, OpenAPI JSON, and SDK support
- improves Hugging Face imports with task aliases and label-name conversion, plus ingestion-compatible endpoint
- adds dataset creation/import UI while keeping the existing dark/gold leaderboard styling
- adds Dockerfiles, docker-compose, MkDocs Material styling aligned with the Documentation repo, and CI for pytest, ruff, mkdocs, lint, and build

## PR / issue audit
- Open PRs reviewed: #23, #24, #25, #26, #27. The relevant fixes are incorporated here directly because #27 is conflicting/failing and the others are narrow stale branches.
- Open issues reviewed and addressed in scope: auth, CORS, rate limiting, validation, remote-code allowlist, audit logging, pagination, response envelope, metadata, export, Docker, OpenAPI, test/CI, dataset UI, ingestion, HF conversion, docs.
- Remaining deeper work intentionally left for later: durable async import jobs and full DB migration tooling beyond the existing schema/compose setup.

## Verification
- python3 -m pytest backend/pytest -q
- python3 -m ruff check backend
- npm run lint
- npm run build
- mkdocs build --strict