### PR TITLE
Improve UI polish and rewrite README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,262 +1,195 @@
-# Anote - Model Leaderboard
+# Anote Model Leaderboard
 
-Anote's Model Leaderboard provides a way to benchmark and compare model performance. We have an API to:
-1. **Adding new datasets** to the leaderboard across **all task types**.
-2. **Adding new model submissions** to existing datasets.
+A transparent, community-driven benchmarking platform for evaluating and ranking AI models across multiple task types and datasets.
 
-The API is the backbone for a transparent, scalable, and community-driven benchmarking platform for AI models, supporting **text classification, named entity recognition, document-level Q&A (chatbot), and line-level Q&A (prompting)**.
-
-
-### API Endpoints
-
-#### `POST /api/leaderboard/add_dataset`
-**Purpose**: Add a new benchmark dataset to the leaderboard.
-**Input (JSON)**:
-```json
-{
-  "name": "Financial Phrasebank - Classification Accuracy",
-  "url": "https://huggingface.co/datasets/takala/financial_phrasebank",
-  "task_type": "text_classification",
-  "description": "A dataset for financial sentiment classification.",
-  "models": [
-    {
-      "rank": 1,
-      "model": "Gemini",
-      "score": 0.95,
-      "ci": "0.93 - 0.97",
-      "updated": "Sep 2024"
-    }
-  ]
-}
-```
-**Response**:
-```json
-{
-  "status": "success",
-  "message": "Dataset added to leaderboard.",
-  "dataset_id": "uuid"
-}
-```
+**Live site:** [leaderboard.anote.ai](https://leaderboard.anote.ai) &nbsp;|&nbsp; **API:** [api.anote.ai](https://api.anote.ai) &nbsp;|&nbsp; **Docs:** [docs.anote.ai](https://docs.anote.ai)
 
 ---
 
-#### `GET /public/benchmark_csvs`
-Purpose: List available CSV benchmark datasets in `frontend/public/benchmark_csvs` with inferred task types and columns.
-Response:
-```
-{
-  "success": true,
-  "datasets": [ { "filename": "Commonsense.csv", "task_type": "multiple_choice", "columns": [ ... ] }, ... ]
-}
-```
+## What it does
 
-#### `POST /public/run_csv_benchmarks`
-Purpose: Evaluate one or more models across selected CSV datasets and return scores.
-Input (JSON):
-```
-{
-  "models": [
-    {"name": "gpt-4o", "provider": "openai", "model": "gpt-4o-mini"},
-    {"name": "llama3", "provider": "ollama", "model": "llama3:8b"},
-    {"name": "echo", "provider": "echo"}
-  ],
-  "datasets": ["Commonsense.csv", "Covid.csv"],  // optional subset; defaults to all
-  "sample_size": 25                                 // optional per dataset
-}
-```
-Response:
-```
-{
-  "success": true,
-  "runs": [
-    { "dataset": "Commonsense.csv", "task_type": "multiple_choice", "count": 25,
-      "results": { "gpt-4o": {"metric": "accuracy", "score": 0.84}, "llama3": {"metric": "accuracy", "score": 0.78} } },
-    { "dataset": "Covid.csv", "task_type": "text_classification", "count": 25,
-      "results": { "gpt-4o": {"metric": "accuracy", "score": 0.92} } }
-  ]
-}
-```
-
-Notes
-- Supported tasks detected from headers: multiple_choice (accuracy), text_classification (accuracy), qa (F1/EM). Others are skipped.
-- Providers:
-  - `openai`: uses `OPENAI_API_KEY` and optional `OPENAI_BASE_URL` for OpenAI-compatible endpoints.
-  - `ollama`: uses `OLLAMA_BASE_URL` (default `http://localhost:11434`).
-  - `echo`: returns a dummy output (useful for dry-runs).
-  - `py`: calls a Python function from `backend/models.py` (see below).
-
-#### Additional Public API Utilities
-
-- `GET /api/metrics`: list metric metadata.
-- `GET /api/metrics/task/<task_type>`: list recommended metrics for a task type.
-- `POST /public/import_hf_dataset`: import a bounded Hugging Face split.
-- `POST /api/datasets/ingest`: ingestion-compatible alias for Hugging Face imports.
-- `GET /public/export/leaderboard?format=csv|json`: export leaderboard rows.
-
-Optional write protection:
-- Set `LEADERBOARD_API_KEYS=key1,key2` to require `X-API-Key` on write/evaluation endpoints.
-- Set per-endpoint rate limits with values such as `SUBMIT_MODEL_RATE_LIMIT=10/minute`.
-- Set `ALLOWED_ORIGINS` explicitly outside local development.
+- **Compare models** on text classification, NER, Q&A, and translation benchmarks
+- **Submit predictions** via the web UI or REST API and get instant scores
+- **Multi-language translation** — Spanish, Arabic, Japanese, Chinese, Korean
+- **Dual metrics** — BLEU (n-gram exact match) and BERTScore (semantic similarity)
+- **CSV benchmarking** — run any model against 20+ bundled datasets in one click
+- **Hugging Face import** — pull any HF dataset split directly into the leaderboard
 
 ---
 
-### Models Catalog (`backend/models.py`)
-Define model wrappers that accept a `prompt` string and return a string response. Env vars supply keys; if `python-dotenv` is installed, `.env` is loaded automatically.
+## Architecture
 
-- Functions: `zero_shot_gpt4o`, `zero_shot_gpt4o_mini`, `zero_shot_claude`, `zero_shot_gemini`, and optional local HF models.
-- Default set used when `POST /public/run_csv_benchmarks` is called without a `models` list comes from `list_models()`.
-- Example `models` item for Python function provider:
 ```
-{ "name": "gpt-4o", "provider": "py", "fn": "zero_shot_gpt4o" }
+Leaderboard/
+├── backend/           # Flask REST API (Python)
+│   ├── app.py         # All API routes (~850 lines)
+│   ├── models.py      # Model provider wrappers (OpenAI, Anthropic, Google, Ollama, echo)
+│   ├── csv_bench.py   # CSV benchmark utilities
+│   ├── sdk/           # Python client SDK
+│   ├── database/      # MySQL schema + init scripts
+│   ├── examples/      # Demo data seed scripts
+│   └── pytest/        # Test suite
+└── frontend/          # React 18 web app
+    ├── src/
+    │   ├── App.js
+    │   ├── landing_page/
+    │   │   ├── LandingPage.js
+    │   │   └── landing_page_components/   # Leaderboard, Evaluations, Submit, etc.
+    │   ├── redux/
+    │   └── constants/
+    └── public/
+        └── benchmark_csvs/                # 20+ CSV benchmark datasets
 ```
 
-Env vars (.env example):
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `GOOGLE_API_KEY`
-- `XAI_API_KEY`
-
-
-#### `POST /api/leaderboard/add_model`
-**Purpose**: Add a new model submission to an existing dataset.
-**Input (JSON)**:
-```json
-{
-  "dataset_name": "Financial Phrasebank - Classification Accuracy",
-  "model": "Llama3",
-  "rank": 4,
-  "score": 0.92,
-  "ci": "0.90 - 0.94",
-  "updated": "Sep 2024"
-}
-```
-**Response**:
-```json
-{
-  "status": "success",
-  "message": "Model added to dataset on leaderboard."
-}
-```
+**Storage:** MySQL is the primary store; the backend automatically falls back to an in-memory store when no DB is configured — no database is required to run locally.
 
 ---
 
-### Supported Task Types
-The API will support datasets across all current and future Anote task types:
-- **Text Classification**
-- **Named Entity Recognition**
-- **Document-Level Q&A (Chatbot)**
-- **Line-Level Q&A (Prompting)**
-- *(Extensible for multimodal tasks and multilingual datasets)*
+## Quickstart
 
----
+### 1. Backend
 
-### 3. Example Code
-Below is a **Flask implementation skeleton**:
+```bash
+cd backend
 
-```python
-from flask import Flask, request, jsonify
-import uuid
+# (Optional) create a virtualenv
+python -m venv .venv && source .venv/bin/activate
 
-app = Flask(__name__)
+# Install dependencies
+pip install -r requirements.txt
 
-leaderboard_data = []  # This would be replaced with a DB in production
-
-@app.route('/api/leaderboard/add_dataset', methods=['POST'])
-def add_dataset():
-    data = request.json
-    dataset_id = str(uuid.uuid4())
-    data['id'] = dataset_id
-    leaderboard_data.append(data)
-    return jsonify({
-        "status": "success",
-        "message": "Dataset added to leaderboard.",
-        "dataset_id": dataset_id
-    })
-
-@app.route('/api/leaderboard/add_model', methods=['POST'])
-def add_model():
-    data = request.json
-    for dataset in leaderboard_data:
-        if dataset['name'] == data['dataset_name']:
-            dataset.setdefault('models', []).append({
-                "rank": data["rank"],
-                "model": data["model"],
-                "score": data["score"],
-                "ci": data["ci"],
-                "updated": data["updated"]
-            })
-            return jsonify({
-                "status": "success",
-                "message": "Model added to dataset on leaderboard."
-            })
-    return jsonify({"status": "error", "message": "Dataset not found."}), 404
-
-if __name__ == '__main__':
-    app.run(debug=True)
+# Start on port 5001 (macOS reserves 5000)
+PORT=5001 FLASK_ENV=development python app.py
 ```
 
----
+Health check: `curl http://localhost:5001/health`
 
-### Integration with Frontend
-The API will integrate with:
-- **Leaderboard Page** ([https://leaderboard.anote.ai/](https://leaderboard.anote.ai/))
-- **Submit to Leaderboard Page** ([https://leaderboard.anote.ai/submit](https://leaderboard.anote.ai/submit))
+### 2. Seed demo data (optional)
 
-This allows direct testing of Flask API calls from the UI to verify real-time table updates.
+In a separate terminal:
 
----
+```bash
+LEADERBOARD_API_BASE=http://localhost:5001 python backend/examples/seed_demo.py
+```
 
-## Quickstart (Local)
+This seeds two demo submissions into the `flores_spanish_translation` dataset.
 
-Run the backend on port 5001 and seed example data, then start the frontend.
+### 3. Frontend
 
-1) Backend
-- Create a virtualenv (optional) and install deps:
-  - `python -m venv .venv && source .venv/bin/activate`
-  - `pip install -r backend/requirements.txt`
-- Start the API on port 5001:
-  - `export PORT=5001 FLASK_ENV=development`
-  - `python backend/app.py`
-- Sanity check: open `http://localhost:5001/` or `http://localhost:5001/health`.
+```bash
+cd frontend
+npm install
+REACT_APP_API_ENDPOINT=http://localhost:5001 npm start
+```
 
-2) Seed demo data (in another terminal)
-- `export LEADERBOARD_API_BASE="http://localhost:5001"`
-- `python backend/examples/seed_demo.py`
-- This seeds two demo submissions to the `flores_spanish_translation` dataset.
+Open [http://localhost:3000](http://localhost:3000). The Evaluations page will show the seeded scores.
 
-3) Frontend
-- In `frontend/`: `npm install`
-- Ensure the frontend points to the backend (default works):
-  - `REACT_APP_API_BASE=http://localhost:5001 npm start`
-- Open the Evaluations page to see demo scores populate.
+### Docker
 
-Docker option:
-- `docker compose up --build`
-- Open `http://localhost:3000` and use `http://localhost:5001` for the API.
+```bash
+docker compose up --build
+```
 
-4) Optional docs site
-- Install MkDocs Material:
-  - `pip install mkdocs-material`
-- Serve the documentation:
-  - `mkdocs serve`
-- Open `http://127.0.0.1:8000`.
-
-Notes
-- The demo uses an in-memory store by default (no DB needed).
-- If you configure MySQL and load `backend/database/schema.sql`, the API will persist to DB.
-- Hugging Face imports require the optional `datasets` package:
-  - `pip install datasets`
+Frontend at `http://localhost:3000`, API at `http://localhost:5001`.
 
 ---
 
-## Metrics and Hugging Face Imports
+## Environment Variables
 
-The API exposes metric metadata copied into this Flask app from the newer Personal implementation:
+### Backend (`backend/.env`)
 
-- `GET /api/metrics` lists all known metric definitions.
-- `GET /api/metrics/task/<task_type>` lists recommended metrics for a task type.
+Copy `backend/.env.example` to `backend/.env` and fill in what you need. **All API keys are optional** — the platform works without them using the `echo` provider.
 
-You can import a bounded Hugging Face dataset split into the leaderboard:
+| Variable | Default | Purpose |
+|---|---|---|
+| `PORT` | `5001` | Flask server port |
+| `OPENAI_API_KEY` | — | OpenAI model evaluation |
+| `ANTHROPIC_API_KEY` | — | Anthropic / Claude evaluation |
+| `GOOGLE_API_KEY` | — | Google Gemini evaluation |
+| `XAI_API_KEY` | — | xAI Grok evaluation |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Local Ollama inference |
+| `DB_HOST` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` | — | MySQL connection (optional) |
+| `LEADERBOARD_API_KEYS` | — | Comma-separated write-endpoint API keys |
+| `ALLOWED_ORIGINS` | dev origins | CORS allowlist (required in production) |
+| `SUBMIT_MODEL_RATE_LIMIT` | `10/minute` | Per-IP rate limit for submissions |
+
+### Frontend
+
+| File | `REACT_APP_API_ENDPOINT` |
+|---|---|
+| `.env.development` | `http://localhost:5000` |
+| `.env.production` | `https://api.anote.ai` |
+
+Override locally: `REACT_APP_API_ENDPOINT=http://localhost:5001 npm start`
+
+---
+
+## API Reference
+
+### Leaderboard
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/` | Welcome / version info |
+| `GET` | `/health` | Health check |
+| `GET` | `/public/datasets` | List benchmark datasets |
+| `POST` | `/public/submit_model` | Submit model predictions for scoring |
+| `GET` | `/public/get_leaderboard` | Ranked model results (paginated) |
+| `GET` | `/public/export/leaderboard` | Export as JSON or CSV |
+| `POST` | `/api/leaderboard/add_dataset` | Add a curated dataset |
+| `POST` | `/api/leaderboard/add_model` | Add a model result to a dataset |
+| `GET` | `/api/leaderboard/list` | List curated datasets |
+
+### Benchmarks & Metrics
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/public/benchmark_csvs` | List bundled CSV benchmark files |
+| `POST` | `/public/run_csv_benchmarks` | Run models against CSV datasets |
+| `GET` | `/api/metrics` | Full metric catalog |
+| `GET` | `/api/metrics/task/<task_type>` | Metrics recommended for a task type |
+
+### Dataset Import
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/public/import_hf_dataset` | Import a Hugging Face dataset split |
+| `POST` | `/api/datasets/ingest` | Ingestion-compatible alias for HF imports |
+| `GET` | `/public/get_source_sentences` | Sentences for translation evaluation |
+| `GET` | `/openapi.json` | OpenAPI machine-readable spec |
+
+### Example: Add a dataset
+
+```bash
+curl -X POST http://localhost:5001/api/leaderboard/add_dataset \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Financial Phrasebank - Classification Accuracy",
+    "url": "https://huggingface.co/datasets/takala/financial_phrasebank",
+    "task_type": "text_classification",
+    "description": "Financial sentiment classification benchmark.",
+    "models": [
+      { "rank": 1, "model": "Gemini", "score": 0.95, "ci": "0.93 - 0.97", "updated": "Sep 2024" }
+    ]
+  }'
+```
+
+### Example: Run CSV benchmarks
+
+```bash
+curl -X POST http://localhost:5001/public/run_csv_benchmarks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "models": [
+      { "name": "gpt-4o", "provider": "openai", "model": "gpt-4o-mini" },
+      { "name": "echo",   "provider": "echo" }
+    ],
+    "datasets": ["Commonsense.csv"],
+    "sample_size": 25
+  }'
+```
+
+### Example: Import from Hugging Face
 
 ```bash
 curl -X POST http://localhost:5001/public/import_hf_dataset \
@@ -270,36 +203,60 @@ curl -X POST http://localhost:5001/public/import_hf_dataset \
   }'
 ```
 
-Use `"preview_only": true` to inspect the converted payload without saving it. Imported datasets are stored in MySQL when configured, otherwise in the local in-memory store for development.
-
-Leaderboard reads support pagination and dataset filtering:
+### Pagination & export
 
 ```bash
+# Paginated leaderboard
 curl "http://localhost:5001/public/get_leaderboard?page=1&page_size=25&dataset=AG%20News%20Test%20Sample"
-```
 
-Exports are available as JSON or CSV:
-
-```bash
+# Export as CSV
 curl "http://localhost:5001/public/export/leaderboard?format=csv" -o leaderboard.csv
 ```
 
 ---
 
-## Example: Programmatic Use (Python SDK)
+## Model Providers
+
+The `provider` field selects the inference backend:
+
+| Provider | Description | Requirement |
+|---|---|---|
+| `openai` | OpenAI API (GPT-4o, etc.) | `OPENAI_API_KEY` |
+| `anthropic` | Anthropic API (Claude) | `ANTHROPIC_API_KEY` |
+| `google` | Google Generative AI (Gemini) | `GOOGLE_API_KEY` |
+| `ollama` | Local Ollama instance | Running Ollama at `OLLAMA_BASE_URL` |
+| `echo` | Dummy provider (returns input) | None — great for dry-runs |
+| `py` | Python function in `models.py` | None |
+
+Define custom Python model wrappers in `backend/models.py`:
+
+```python
+# backend/models.py
+def my_custom_model(prompt: str) -> str:
+    # call your model here
+    return "model output"
+```
+
+Then reference it as `{ "name": "my-model", "provider": "py", "fn": "my_custom_model" }`.
+
+---
+
+## Python SDK
 
 ```python
 from backend.sdk.leaderboard_sdk import LeaderboardClient
 
 client = LeaderboardClient(base_url="http://localhost:5001")
 
-# Curated leaderboard entries (for the homepage tiles)
+# Add a curated dataset
 client.add_dataset(
     name="Financial Phrasebank - Classification Accuracy",
     task_type="text_classification",
     url="https://huggingface.co/datasets/takala/financial_phrasebank",
-    description="A dataset for financial sentiment classification.",
+    description="Financial sentiment classification benchmark.",
 )
+
+# Add a model result
 client.add_model(
     dataset_name="Financial Phrasebank - Classification Accuracy",
     model="Llama3",
@@ -307,17 +264,92 @@ client.add_model(
     score=0.92,
     updated="Sep 2024",
 )
+
+# List all datasets
 print(client.list_datasets())
 
-# Public evaluation flow (translation demo)
+# Submit model translations for scoring
 src = client.get_source_sentences(dataset_name="flores_spanish_translation", count=3)
-sentence_ids = src["sentence_ids"]
-model_results = src["source_sentences"]  # echo back for high BLEU in demo
 print(client.submit_model(
     benchmark_dataset_name="flores_spanish_translation",
     model_name="my-demo-model",
-    model_results=model_results,
-    sentence_ids=sentence_ids,
+    model_results=src["source_sentences"],  # echo back for demo
+    sentence_ids=src["sentence_ids"],
 ))
+
+# Get full leaderboard
 print(client.get_leaderboard())
 ```
+
+---
+
+## Supported Task Types
+
+| Task | Metric | Notes |
+|---|---|---|
+| `text_classification` | Accuracy | Single or multi-label |
+| `named_entity_recognition` | F1 | Span-level evaluation |
+| `document_qa` | F1 / Exact Match | Document-context Q&A |
+| `line_qa` | F1 / Exact Match | Prompt-style Q&A |
+| `translation` | BLEU + BERTScore | BLEU≈0 for Asian scripts; always use BERTScore for JA/ZH/KO |
+| `multiple_choice` | Accuracy | CSV datasets with answer columns |
+
+---
+
+## Testing
+
+```bash
+cd backend
+python -m pytest pytest/ -v
+```
+
+Tests cover endpoint integration, SDK usage, BLEU/BERTScore scoring for all 5 translation languages, and leaderboard ranking.
+
+See [`backend/pytest/TESTING_GUIDE.md`](backend/pytest/TESTING_GUIDE.md) for the full guide with 13+ test scenarios.
+
+---
+
+## Adding Things
+
+### New API endpoint
+1. Add the route in `backend/app.py` following existing patterns.
+2. Add a test in `backend/pytest/test_dataset_endpoints.py`.
+
+### New model provider
+1. Add a wrapper function in `backend/models.py`.
+2. Register it in the provider dispatch logic in `app.py`.
+
+### New CSV benchmark dataset
+1. Place the `.csv` file in `frontend/public/benchmark_csvs/`.
+2. Ensure headers are recognizable by `csv_bench.py`'s `infer_task_type()`.
+
+### New frontend component
+1. Create the component in `frontend/src/landing_page/landing_page_components/`.
+2. Import and render it in `LandingPage.js`.
+3. Add the route to `src/constants/RouteConstants.js` if it needs its own page.
+
+---
+
+## Security
+
+- Set `LEADERBOARD_API_KEYS=key1,key2` to require `X-API-Key` on write endpoints.
+- Set `REQUIRE_API_KEY=true` to enforce key auth globally.
+- Set `ALLOWED_ORIGINS` explicitly in production (required).
+- Per-endpoint rate limits: `SUBMIT_MODEL_RATE_LIMIT`, `ADD_DATASET_RATE_LIMIT`, `RUN_CSV_RATE_LIMIT`.
+
+---
+
+## Optional: Documentation Site
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Open [http://127.0.0.1:8000](http://127.0.0.1:8000).
+
+---
+
+## Contact
+
+Questions or issues? Email [nvidra@anote.ai](mailto:nvidra@anote.ai) or visit [anote.ai](https://anote.ai).

--- a/frontend/src/landing_page/landing_page_components/Evaluations.js
+++ b/frontend/src/landing_page/landing_page_components/Evaluations.js
@@ -97,36 +97,39 @@ const Evaluations = () => {
             <span className="w-1.5 h-1.5 rounded-full bg-[#defe47] animate-pulse" />
             Live Results
           </div>
-          <h1 className="text-4xl sm:text-5xl font-extrabold bg-gradient-to-r from-[#defe47] via-[#b8f030] to-[#28b2fb] bg-clip-text text-transparent mb-5 leading-tight">
+          <h1 className="text-4xl sm:text-5xl font-extrabold bg-gradient-to-r from-[#defe47] via-[#b8f030] to-[#28b2fb] bg-clip-text text-transparent mb-3 leading-tight">
             Evaluation Leaderboard
           </h1>
+          <p className="text-gray-400 text-sm md:text-base max-w-lg mx-auto mb-6 leading-relaxed">
+            Live results from model submissions across all benchmark datasets.
+          </p>
 
-          {/* <div className="flex flex-wrap items-center justify-center gap-2 mb-7">
+          <div className="flex flex-wrap items-center justify-center gap-2 mb-7">
             <button
-              className="px-5 py-2.5 rounded-lg border border-[#defe47] bg-[#defe47] text-black font-semibold text-sm hover:bg-[#eeff5a] transition-colors active:scale-95 shadow-lg shadow-[#defe47]/10"
+              className="px-4 py-2 rounded-lg border border-[#defe47] bg-[#defe47] text-black font-semibold text-sm hover:bg-[#eeff5a] transition-colors active:scale-95 shadow-lg shadow-[#defe47]/10"
               onClick={() => navigate("/")}
             >
               Main Leaderboard
             </button>
             <button
-              className="px-5 py-2.5 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/50 hover:text-[#28b2fb] transition-colors active:scale-95"
+              className="px-4 py-2 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#defe47]/40 hover:text-[#defe47] transition-colors active:scale-95"
               onClick={() => navigate(submittoleaderboardPath)}
             >
               Submit Model
             </button>
             <button
-              className="px-5 py-2.5 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/50 hover:text-[#28b2fb] transition-colors active:scale-95"
+              className="px-4 py-2 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/40 hover:text-[#28b2fb] transition-colors active:scale-95"
               onClick={() => navigate(addDatasetPath)}
             >
               Add Dataset
             </button>
             <button
-              className="px-5 py-2.5 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/50 hover:text-[#28b2fb] transition-colors active:scale-95"
+              className="px-4 py-2 rounded-lg border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/40 hover:text-[#28b2fb] transition-colors active:scale-95"
               onClick={() => navigate(csvBenchmarksPath)}
             >
               Run Benchmarks
             </button>
-          </div> */}
+          </div>
           <div className="max-w-xl mx-auto">
             <div className="relative">
               <svg className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/frontend/src/landing_page/landing_page_components/Footer.js
+++ b/frontend/src/landing_page/landing_page_components/Footer.js
@@ -20,7 +20,7 @@ function Footer() {
   ];
 
   return (
-    <footer className="bg-gray-800 border-t border-white/[0.05]">
+    <footer className="bg-[#080d16] border-t border-white/[0.05]">
       <div className="max-w-7xl mx-auto px-6 py-12">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
 
@@ -29,14 +29,18 @@ function Footer() {
             <div className="flex items-center gap-2.5 mb-3">
               <img src="/logo.png" alt="Anote" className="h-8 w-8" loading="lazy" />
               <span className="text-lg font-bold text-white">Anote</span>
+              <span className="text-xs text-gray-600 font-medium">Leaderboard</span>
             </div>
-            <p className="text-sm text-gray-400 max-w-xs leading-relaxed mb-4">
+            <p className="text-sm text-gray-500 max-w-xs leading-relaxed mb-4">
               Transparent, community-driven benchmarking for AI models. Compare, submit, and track performance across diverse evaluation datasets.
             </p>
             <a
               href="mailto:nvidra@anote.ai"
-              className="text-sm text-[#28b2fb] hover:text-[#defe47] transition-colors"
+              className="inline-flex items-center gap-1.5 text-sm text-[#28b2fb] hover:text-[#defe47] transition-colors"
             >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
               nvidra@anote.ai
             </a>
           </div>
@@ -52,7 +56,7 @@ function Footer() {
                   <button
                     type="button"
                     onClick={() => navigate(path)}
-                    className="text-sm text-gray-400 hover:text-white transition-colors"
+                    className="text-sm text-gray-500 hover:text-white transition-colors"
                   >
                     {label}
                   </button>
@@ -72,7 +76,7 @@ function Footer() {
                   href="https://anote.ai"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-gray-400 hover:text-white transition-colors"
+                  className="text-sm text-gray-500 hover:text-white transition-colors"
                 >
                   Anote.ai →
                 </a>
@@ -82,7 +86,7 @@ function Footer() {
                   href="https://anote-ai.medium.com/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-gray-400 hover:text-white transition-colors"
+                  className="text-sm text-gray-500 hover:text-white transition-colors"
                 >
                   Blog
                 </a>
@@ -92,7 +96,7 @@ function Footer() {
                   href="https://www.linkedin.com/company/anote-ai"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-gray-400 hover:text-white transition-colors"
+                  className="text-sm text-gray-500 hover:text-white transition-colors"
                 >
                   LinkedIn
                 </a>
@@ -102,7 +106,7 @@ function Footer() {
                   href="https://docs.anote.ai"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-gray-400 hover:text-white transition-colors"
+                  className="text-sm text-gray-500 hover:text-white transition-colors"
                 >
                   Documentation
                 </a>
@@ -113,14 +117,14 @@ function Footer() {
         </div>
 
         {/* Bottom bar */}
-        <div className="mt-10 pt-6 border-t border-gray-800/50 flex flex-col sm:flex-row justify-between items-center gap-3">
-          <p className="text-xs text-gray-500">© {year} Anote. All rights reserved.</p>
+        <div className="mt-10 pt-6 border-t border-gray-800/40 flex flex-col sm:flex-row justify-between items-center gap-3">
+          <p className="text-xs text-gray-600">© {year} Anote AI. All rights reserved.</p>
           <div className="flex items-center gap-4">
             <a
               href="https://anote.ai/privacypolicy"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              className="text-xs text-gray-600 hover:text-gray-300 transition-colors"
             >
               Privacy Policy
             </a>
@@ -131,16 +135,16 @@ function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Medium"
-                className="text-gray-500 hover:text-white transition-colors"
+                className="text-gray-600 hover:text-white transition-colors"
               >
-                <img className="w-4 h-4 opacity-60 hover:opacity-100 transition-opacity" src="/landing_page_assets/social/medium.svg" alt="Medium" loading="lazy" />
+                <img className="w-4 h-4 opacity-50 hover:opacity-100 transition-opacity" src="/landing_page_assets/social/medium.svg" alt="Medium" loading="lazy" />
               </a>
               <a
                 href="https://www.linkedin.com/company/anote-ai"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="LinkedIn"
-                className="text-gray-500 hover:text-[#28b2fb] transition-colors"
+                className="text-gray-600 hover:text-[#28b2fb] transition-colors"
               >
                 <svg fill="currentColor" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="0" className="w-4 h-4" viewBox="0 0 24 24">
                   <path stroke="none" d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-2-2 2 2 0 00-2 2v7h-4v-7a6 6 0 016-6zM2 9h4v12H2z" />

--- a/frontend/src/landing_page/landing_page_components/HeaderBar.js
+++ b/frontend/src/landing_page/landing_page_components/HeaderBar.js
@@ -25,24 +25,27 @@ export default function HeaderBar() {
       <div className="max-w-7xl mx-auto px-4">
         <div className="h-14 flex items-center justify-between">
           {/* Logo */}
-          <button
-            type="button"
-            onClick={() => navigate('/')}
-            className="flex items-center gap-2.5 shrink-0"
-            aria-label="Go to leaderboard home"
-          >
-            <img src="/logo.png" alt="Anote" className="h-7 w-7" />
-              <a
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={() => navigate('/')}
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+              aria-label="Go to leaderboard home"
+            >
+              <img src="/logo.png" alt="Anote" className="h-7 w-7" />
+            </button>
+            <a
               href="https://anote.ai"
               target="_blank"
               rel="noopener noreferrer"
-              className="ml-2 px-3 py-1.5 rounded-lg font-medium  hover:bg-[#28b2fb]/[0.08] transition-all duration-150"
+              className="font-bold text-white hover:text-[#defe47] transition-colors duration-150 text-sm"
             >
-                          <span className="font-bold text-white">
               Anote
-                          </span>
             </a>
-          </button>
+            <span className="hidden sm:inline-block text-gray-700 text-xs font-medium ml-1 px-1.5 py-0.5 rounded bg-gray-800/60 border border-gray-700/40">
+              Leaderboard
+            </span>
+          </div>
 
           {/* Desktop nav */}
           <nav className="hidden sm:flex items-center gap-0.5">
@@ -52,23 +55,26 @@ export default function HeaderBar() {
                 type="button"
                 onClick={() => navigate(item.path)}
                 className={[
-                  "px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150",
+                  "relative px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150",
                   isActive(item.path)
                     ? "text-[#defe47] font-semibold"
-                    : "text-gray-400 hover:text-gray-100"
+                    : "text-gray-400 hover:text-gray-100 hover:bg-white/[0.04]"
                 ].join(' ')}
               >
                 {item.label}
+                {isActive(item.path) && (
+                  <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-[#defe47]" />
+                )}
               </button>
             ))}
-            {/* <a
+            <a
               href="https://anote.ai"
               target="_blank"
               rel="noopener noreferrer"
-              className="ml-2 px-3 py-1.5 rounded-lg text-sm font-medium text-[#28b2fb] border border-[#28b2fb]/20 hover:bg-[#28b2fb]/[0.08] transition-all duration-150"
+              className="ml-2 px-3 py-1.5 rounded-lg text-sm font-medium text-[#28b2fb] border border-[#28b2fb]/20 hover:bg-[#28b2fb]/[0.08] hover:border-[#28b2fb]/40 transition-all duration-150"
             >
               Anote.ai ↗
-            </a> */}
+            </a>
           </nav>
 
           {/* Mobile hamburger */}
@@ -101,21 +107,21 @@ export default function HeaderBar() {
                 className={[
                   "px-3 py-2 rounded-lg text-sm font-medium text-left transition-all",
                   isActive(item.path)
-                    ? "bg-[#defe47] text-black font-semibold"
+                    ? "bg-[#defe47]/10 text-[#defe47] font-semibold border border-[#defe47]/20"
                     : "text-gray-400 hover:text-gray-100 hover:bg-white/[0.06]"
                 ].join(' ')}
               >
                 {item.label}
               </button>
             ))}
-            {/* <a
+            <a
               href="https://anote.ai"
               target="_blank"
               rel="noopener noreferrer"
               className="px-3 py-2 rounded-lg text-sm font-medium text-[#28b2fb] hover:bg-[#28b2fb]/[0.08] transition-all"
             >
               Anote.ai ↗
-            </a> */}
+            </a>
           </div>
         )}
       </div>

--- a/frontend/src/landing_page/landing_page_components/Leaderboard.js
+++ b/frontend/src/landing_page/landing_page_components/Leaderboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { addDatasetPath, csvBenchmarksPath, evaluationsPath, submittoleaderboardPath } from "../../constants/RouteConstants";
 import { useNavigate } from "react-router-dom";
 
@@ -9,6 +9,7 @@ const Leaderboard = () => {
   const [viewMode, setViewMode] = useState('live'); // 'live' | 'curated'
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
   const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
 
   useEffect(() => {
@@ -68,9 +69,9 @@ const Leaderboard = () => {
 
   const faqs = [
     {
-      question: "Where can I find the evaluation datasets",
+      question: "Where can I find the evaluation datasets?",
       answer:
-        "You can access the evaluation set by following the dataset link listed with our submittoleaderboard component. If you have difficulty downloading them or need direct access, just send us an email at nvidra@anote.ai and we will provide the questions promptly.",
+        "You can access the evaluation set by following the dataset link listed on each leaderboard card. If you have difficulty downloading them or need direct access, just send us an email at nvidra@anote.ai and we will provide the data promptly.",
     },
     {
       question: "How many times can I submit?",
@@ -130,7 +131,7 @@ const Leaderboard = () => {
         },
         {
           rank: 5,
-          model: "Query Expansiong",
+          model: "Query Expansion",
           score: 0.256,
           ci: "0.24 - 0.27",
           updated: "Sep 2024",
@@ -1027,9 +1028,19 @@ const Leaderboard = () => {
   ];
   const navigate = useNavigate();
 
-  const displayDatasets = viewMode === 'curated'
+  const baseDatasets = viewMode === 'curated'
     ? (curatedDatasets.length ? curatedDatasets : datasets)
     : (liveDatasets.length ? liveDatasets : datasets);
+
+  const displayDatasets = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return baseDatasets;
+    return baseDatasets.filter(d =>
+      (d.name || '').toLowerCase().includes(q) ||
+      (d.evaluation_metric || '').toLowerCase().includes(q) ||
+      (d.models || []).some(m => (m.model || '').toLowerCase().includes(q))
+    );
+  }, [baseDatasets, query]);
 
   const rankBadge = (rank) => {
     if (rank === 1) return <span title="1st place" className="mr-1">🥇</span>;
@@ -1045,41 +1056,119 @@ const Leaderboard = () => {
       <header className="w-full max-w-4xl mt-10 pt-4 text-center relative">
         {/* Subtle glow behind headline */}
         <div className="absolute inset-0 -top-10 flex items-center justify-center pointer-events-none">
-          <div className="w-96 h-40 rounded-full bg-[#defe47]/[0.04] blur-3xl" />
+          <div className="w-96 h-40 rounded-full bg-[#defe47]/[0.05] blur-3xl" />
         </div>
         <div className="relative">
-          {/* <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#28b2fb]/[0.08] border border-[#28b2fb]/20 text-xs uppercase tracking-[0.18em] text-[#28b2fb] mb-4 font-medium">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#28b2fb]/[0.08] border border-[#28b2fb]/20 text-xs uppercase tracking-[0.18em] text-[#28b2fb] mb-4 font-medium">
             <span className="w-1.5 h-1.5 rounded-full bg-[#28b2fb] animate-pulse" />
             Anote Evaluations
-          </div> */}
-          <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight bg-white bg-clip-text text-transparent leading-tight">
+          </div>
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight bg-gradient-to-r from-white via-gray-100 to-gray-300 bg-clip-text text-transparent leading-tight">
             Model Leaderboard
           </h1>
           <p className="mt-4 text-gray-400 text-sm md:text-base max-w-lg mx-auto leading-relaxed">
-            Compare models, submit results, and track model performance.
+            Transparent, community-driven benchmarks for AI models. Compare performance, submit results, and explore evaluation datasets.
           </p>
+
+          {/* CTA buttons */}
+          <div className="mt-7 flex flex-wrap items-center justify-center gap-3">
+            <button
+              onClick={() => navigate(submittoleaderboardPath)}
+              className="px-5 py-2.5 rounded-xl bg-[#defe47] text-black text-sm font-semibold hover:bg-[#eeff5a] active:scale-95 transition-all shadow-lg shadow-[#defe47]/10"
+            >
+              Submit a Model
+            </button>
+            <button
+              onClick={() => navigate(addDatasetPath)}
+              className="px-5 py-2.5 rounded-xl border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#defe47]/40 hover:text-[#defe47] active:scale-95 transition-all"
+            >
+              Add Dataset
+            </button>
+            <button
+              onClick={() => navigate(csvBenchmarksPath)}
+              className="px-5 py-2.5 rounded-xl border border-gray-700/80 text-gray-300 text-sm font-medium hover:border-[#28b2fb]/40 hover:text-[#28b2fb] active:scale-95 transition-all"
+            >
+              Run Benchmarks
+            </button>
+          </div>
         </div>
       </header>
 
-
-      {/* ── Loading / error ── */}
-      {loading && (
-        <div className="mt-16 text-gray-400 flex items-center gap-2.5 text-sm">
-          <svg className="animate-spin w-4 h-4 text-[#28b2fb]" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-          </svg>
-          Loading leaderboard…
+      {/* ── Controls: view toggle + search ── */}
+      <div className="w-full max-w-7xl mt-10 flex flex-col sm:flex-row items-center justify-between gap-4">
+        {/* View toggle */}
+        <div className="flex items-center gap-1 p-1 bg-[#0d1421] rounded-xl border border-gray-800/80">
+          {[
+            { key: 'live', label: 'Live Results' },
+            { key: 'curated', label: 'Curated' },
+          ].map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setViewMode(key)}
+              className={[
+                "px-4 py-1.5 rounded-lg text-sm font-medium transition-all duration-150",
+                viewMode === key
+                  ? "bg-[#defe47] text-black shadow-sm"
+                  : "text-gray-400 hover:text-gray-100"
+              ].join(' ')}
+            >
+              {label}
+            </button>
+          ))}
         </div>
-      )}
+
+        {/* Search */}
+        <div className="relative w-full sm:max-w-xs">
+          <svg className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 111 11a6 6 0 0116 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Filter by dataset or model…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 rounded-xl bg-[#0d1421] border border-gray-800/80 text-gray-200 placeholder-gray-600 focus:outline-none focus:border-[#28b2fb]/40 text-sm transition-colors"
+          />
+        </div>
+      </div>
+
+      {/* ── Error ── */}
       {error && (
-        <div className="mt-10 text-red-400 text-sm bg-red-900/20 border border-red-800/40 rounded-lg px-4 py-2.5">
+        <div className="mt-6 text-red-400 text-sm bg-red-900/20 border border-red-800/40 rounded-lg px-4 py-2.5 w-full max-w-7xl">
           {error}
         </div>
       )}
 
       {/* ── Dataset cards ── */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-6 mt-10 w-full max-w-7xl">
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-6 mt-6 w-full max-w-7xl">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="bg-[#0d1421] rounded-2xl border border-gray-800/80 animate-pulse overflow-hidden">
+              <div className="px-5 pt-5 pb-4 border-b border-gray-800/60">
+                <div className="h-4 bg-gray-800/80 rounded-lg w-2/3 mb-3" />
+                <div className="h-3 bg-gray-800/60 rounded-full w-1/4" />
+              </div>
+              <div className="px-5 py-3 border-b border-gray-800/40">
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="h-2.5 bg-gray-800/60 rounded" />
+                  <div className="h-2.5 bg-gray-800/60 rounded" />
+                  <div className="h-2.5 bg-gray-800/60 rounded" />
+                </div>
+              </div>
+              {[...Array(4)].map((__, j) => (
+                <div key={j} className="px-5 py-3 border-b border-gray-800/30">
+                  <div className="grid grid-cols-[3rem_1fr_5rem] gap-4 items-center">
+                    <div className="h-5 w-5 bg-gray-800/70 rounded-full" />
+                    <div className="h-3 bg-gray-800/60 rounded w-3/4" />
+                    <div className="h-3 bg-gray-800/60 rounded w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-6 mt-6 w-full max-w-7xl">
         {displayDatasets.map((dataset, index) => (
           <div
             key={index}
@@ -1175,6 +1264,14 @@ const Leaderboard = () => {
           </div>
         ))}
       </div>
+      )}
+
+      {/* ── Empty state ── */}
+      {!loading && displayDatasets.length === 0 && (
+        <div className="mt-10 text-gray-400 bg-[#0d1421] border border-gray-800/80 p-6 rounded-xl w-full max-w-7xl text-center text-sm">
+          {query ? `No datasets match "${query}".` : 'No leaderboard data yet. Add a dataset or submit model outputs to populate this view.'}
+        </div>
+      )}
 
       {/* ── FAQs ── */}
       <div className="w-full max-w-3xl mx-auto mt-24 px-2">


### PR DESCRIPTION
## Summary

- **HeaderBar**: Fix invalid nested `<a>`/`<button>` HTML, add active-page dot indicator, restore Anote.ai external link, add "Leaderboard" label badge in desktop nav, improve mobile active state styling
- **Leaderboard**: Add hero CTA buttons (Submit a Model / Add Dataset / Run Benchmarks), add Live/Curated view toggle pill, add search/filter input for datasets and models, replace spinner loading with skeleton card placeholders, add empty-state message, fix "Query Expansiong" typo, fix FAQ copy that referenced an internal component name
- **Evaluations**: Restore the action-button row below the title (previously commented out), add subtitle description paragraph below the heading
- **Footer**: Match dark theme background (`#080d16` instead of `gray-800`), add "Leaderboard" sub-label in brand, add email icon, soften link text to `gray-500` for better hierarchy
- **README**: Full rewrite with structured sections — quickstart, complete API reference table, provider guide, Python SDK example, task-type table, security notes, and contributing guide

## Test plan

- [ ] Visit `/` — confirm hero shows CTA buttons, view toggle (Live/Curated), and search bar; skeleton cards appear on load
- [ ] Type in the search box — confirm cards filter by dataset name or model name
- [ ] Click "Curated" toggle — confirm view switches; click "Live Results" to switch back
- [ ] Visit `/evaluations` — confirm action buttons row is visible below the title
- [ ] Check header on desktop — confirm active route shows yellow dot indicator and "Anote.ai ↗" external link appears
- [ ] Check header on mobile — confirm hamburger menu works, active item uses yellow tint style
- [ ] Scroll to footer — confirm dark background matches the rest of the page
- [ ] Review README.md in GitHub — confirm all sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)