### PR TITLE
Add AWS deploy workflow and CODEBASE_SETUP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,3 +99,17 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id $CF_DISTRIBUTION --paths "/*"
+
+  notify:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [deploy-backend, deploy-frontend]
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@v1
+        continue-on-error: true
+        with:
+          payload: |
+            {"text": "Deploy FAILED on `${{ github.ref_name }}` — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,101 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: production
+        type: choice
+        options: [production, staging]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-backend:
+    name: Deploy Backend to ECS
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'production' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push backend image
+        working-directory: backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: leaderboard-backend
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+                     $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+      - name: Deploy to ECS
+        env:
+          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          ECS_SERVICE: ${{ secrets.ECS_SERVICE_BACKEND }}
+        run: |
+          aws ecs update-service \
+            --cluster $ECS_CLUSTER \
+            --service $ECS_SERVICE \
+            --force-new-deployment
+          aws ecs wait services-stable \
+            --cluster $ECS_CLUSTER \
+            --services $ECS_SERVICE
+
+  deploy-frontend:
+    name: Deploy Frontend to S3/CloudFront
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'production' }}
+    needs: deploy-backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps
+      - name: Build
+        working-directory: frontend
+        env:
+          REACT_APP_BACK_END_HOST: ${{ secrets.REACT_APP_BACK_END_HOST }}
+          CI: false
+        run: npm run build
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+      - name: Deploy to S3
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET_FRONTEND }}
+        run: |
+          aws s3 sync frontend/build/ s3://$S3_BUCKET --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" --exclude "*.json"
+          aws s3 cp frontend/build/index.html s3://$S3_BUCKET/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+          aws s3 sync frontend/build/ s3://$S3_BUCKET \
+            --exclude "*" --include "*.json" --cache-control "no-cache"
+      - name: Invalidate CloudFront
+        env:
+          CF_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id $CF_DISTRIBUTION --paths "/*"

--- a/CODEBASE_SETUP.md
+++ b/CODEBASE_SETUP.md
@@ -2,21 +2,21 @@
 
 ## What is Leaderboard?
 
-Leaderboard is an LLM performance ranking platform available at [anote.ai/leaderboard](https://anote.ai/leaderboard). It tracks and compares model quality across tasks and datasets, giving teams an objective view of which models perform best for their use cases.
+Leaderboard provides LLM performance rankings hosted at [anote.ai/leaderboard](https://anote.ai/leaderboard). It benchmarks and compares language models across a variety of tasks and domains.
 
 ## Architecture
 
 | Layer | Technology | Location |
 |-------|-----------|----------|
-| Frontend | React (Node 18) | `frontend/` |
+| Frontend | React (Create React App) | `frontend/` |
 | Backend | Python 3.11, FastAPI | `backend/` |
 | Container orchestration | Docker Compose | `docker-compose.yml` |
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (v2+)
-- Node 18 (only needed for manual frontend setup)
-- Python 3.11 (only needed for manual backend setup)
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (recommended path)
+- Node 18+ (manual frontend setup)
+- Python 3.11+ (manual backend setup)
 
 ## Quick Start with Docker Compose (RECOMMENDED)
 
@@ -25,9 +25,8 @@ Leaderboard is an LLM performance ranking platform available at [anote.ai/leader
 git clone https://github.com/anote-ai/Leaderboard.git
 cd Leaderboard
 
-# 2. Copy and fill in environment variables
+# 2. Create your local env file and fill in values
 cp .env.example .env
-# Edit .env and set the required values
 
 # 3. Start all services
 docker-compose up --build
@@ -43,53 +42,57 @@ docker-compose up --build
 ```bash
 cd backend
 pip install -e ".[dev]"
-uvicorn app:app --reload --host 0.0.0.0 --port 8000
+uvicorn app:app --reload --port 8000
 ```
 
-Dependencies are declared in `pyproject.toml`. The `[dev]` extra includes linting and testing tools.
+Dependencies are declared in `pyproject.toml` at the repo root.
 
 ### Frontend
 
 ```bash
 cd frontend
 npm install
-npm start
+npm start   # starts on http://localhost:3000
 ```
-
-The dev server starts at `http://localhost:3000`.
 
 ## Environment Variables
 
-Copy `.env.example` to `.env` and fill in the values.
+Copy `.env.example` to `.env` and set the following:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `OPENAI_API_KEY` | Yes | OpenAI API key |
-| `ANTHROPIC_API_KEY` | No | Anthropic API key for Claude models |
-| `SECRET_KEY` | Yes | Random secret for session signing |
-| `REACT_APP_BACK_END_HOST` | Yes | Backend URL seen by the browser |
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `OPENAI_API_KEY` | OpenAI API key for LLM evaluation calls |
+| `REACT_APP_BACK_END_HOST` | Backend URL consumed by the React app |
 
-## CI/CD
+## Dependency Management
+
+Python dependencies are managed via `pyproject.toml`. Install everything including dev tools with:
+
+```bash
+pip install -e ".[dev]"
+```
+
+## CI / CD
 
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
-| `backend.yml` | PR / push to main | Runs backend tests |
-| `ci.yml` | PR / push to main | Lint and type checks |
-| `deploy.yml` | Manual (`workflow_dispatch`) | Builds Docker image → ECR → ECS (backend); React build → S3 → CloudFront (frontend) |
+| `backend.yml` | Pull request | Runs backend tests |
+| `ci.yml` | Pull request | Lint and type-check |
+| `deploy.yml` | Manual (`workflow_dispatch`) | Builds Docker image (ECR repository: `leaderboard-backend`) → pushes to ECR → updates ECS service; syncs frontend build to S3 and invalidates CloudFront |
 
 ### Required GitHub Secrets for Deployment
 
-Configure these in **Settings → Secrets and variables → Actions**:
+Set these in **Settings → Secrets and variables → Actions**:
 
 | Secret | Description |
 |--------|-------------|
-| `AWS_ACCESS_KEY_ID` | IAM access key with ECR/ECS/S3/CloudFront permissions |
-| `AWS_SECRET_ACCESS_KEY` | Corresponding IAM secret key |
-| `AWS_REGION` | AWS region (defaults to `us-east-1`) |
-| `ECS_CLUSTER` | ECS cluster name |
-| `ECS_SERVICE_BACKEND` | ECS service name for the backend |
-| `S3_BUCKET_FRONTEND` | S3 bucket for the React build (ECR repository: `leaderboard-backend`) |
-| `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution ID |
-| `REACT_APP_BACK_END_HOST` | Backend URL injected at build time |
-| `SLACK_WEBHOOK_URL` | (Optional) Slack webhook for failure alerts |
+| `AWS_ACCESS_KEY_ID` | IAM access key with ECS/ECR/S3/CloudFront permissions |
+| `AWS_SECRET_ACCESS_KEY` | Corresponding IAM secret |
+| `AWS_REGION` | AWS region, e.g. `us-east-1` |
+| `ECS_CLUSTER` | Name of the ECS cluster |
+| `ECS_SERVICE_BACKEND` | Name of the ECS service for the backend |
+| `S3_BUCKET_FRONTEND` | S3 bucket name for the frontend static files |
+| `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution ID to invalidate after deploy |
+| `REACT_APP_BACK_END_HOST` | Backend URL injected at React build time |
+| `SLACK_WEBHOOK_URL` | (Optional) Slack incoming webhook for failure notifications |

--- a/CODEBASE_SETUP.md
+++ b/CODEBASE_SETUP.md
@@ -1,0 +1,95 @@
+# Leaderboard — Codebase Setup
+
+## What is Leaderboard?
+
+Leaderboard is an LLM performance ranking platform available at [anote.ai/leaderboard](https://anote.ai/leaderboard). It tracks and compares model quality across tasks and datasets, giving teams an objective view of which models perform best for their use cases.
+
+## Architecture
+
+| Layer | Technology | Location |
+|-------|-----------|----------|
+| Frontend | React (Node 18) | `frontend/` |
+| Backend | Python 3.11, FastAPI | `backend/` |
+| Container orchestration | Docker Compose | `docker-compose.yml` |
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) (v2+)
+- Node 18 (only needed for manual frontend setup)
+- Python 3.11 (only needed for manual backend setup)
+
+## Quick Start with Docker Compose (RECOMMENDED)
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/anote-ai/Leaderboard.git
+cd Leaderboard
+
+# 2. Copy and fill in environment variables
+cp .env.example .env
+# Edit .env and set the required values
+
+# 3. Start all services
+docker-compose up --build
+```
+
+- Frontend: [http://localhost:3000](http://localhost:3000)
+- Backend API: [http://localhost:8000](http://localhost:8000)
+
+## Manual Setup (without Docker)
+
+### Backend
+
+```bash
+cd backend
+pip install -e ".[dev]"
+uvicorn app:app --reload --host 0.0.0.0 --port 8000
+```
+
+Dependencies are declared in `pyproject.toml`. The `[dev]` extra includes linting and testing tools.
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The dev server starts at `http://localhost:3000`.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the values.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `OPENAI_API_KEY` | Yes | OpenAI API key |
+| `ANTHROPIC_API_KEY` | No | Anthropic API key for Claude models |
+| `SECRET_KEY` | Yes | Random secret for session signing |
+| `REACT_APP_BACK_END_HOST` | Yes | Backend URL seen by the browser |
+
+## CI/CD
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `backend.yml` | PR / push to main | Runs backend tests |
+| `ci.yml` | PR / push to main | Lint and type checks |
+| `deploy.yml` | Manual (`workflow_dispatch`) | Builds Docker image → ECR → ECS (backend); React build → S3 → CloudFront (frontend) |
+
+### Required GitHub Secrets for Deployment
+
+Configure these in **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | IAM access key with ECR/ECS/S3/CloudFront permissions |
+| `AWS_SECRET_ACCESS_KEY` | Corresponding IAM secret key |
+| `AWS_REGION` | AWS region (defaults to `us-east-1`) |
+| `ECS_CLUSTER` | ECS cluster name |
+| `ECS_SERVICE_BACKEND` | ECS service name for the backend |
+| `S3_BUCKET_FRONTEND` | S3 bucket for the React build (ECR repository: `leaderboard-backend`) |
+| `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution ID |
+| `REACT_APP_BACK_END_HOST` | Backend URL injected at build time |
+| `SLACK_WEBHOOK_URL` | (Optional) Slack webhook for failure alerts |


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml`: manual `workflow_dispatch` workflow that deploys the Python/FastAPI backend to AWS ECS (via ECR, repository `leaderboard-backend`) and the React frontend to S3 + CloudFront
- Adds `CODEBASE_SETUP.md` covering architecture, Docker Compose quick start (frontend at localhost:3000, backend at localhost:8000), manual setup, environment variables, and required GitHub Secrets

## Test plan

- [ ] Review `deploy.yml` for correctness of ECR repository name (`leaderboard-backend`), working directory (`backend/`), and secret references
- [ ] Confirm all listed GitHub Secrets exist under Settings → Secrets and variables → Actions before triggering
- [ ] Trigger the workflow manually via Actions → Deploy → Run workflow and verify both jobs complete
- [ ] Verify `CODEBASE_SETUP.md` renders correctly and the quick-start steps work on a fresh clone

---
_Generated by [Claude Code](https://claude.ai/code/session_012pfuzH2vguMpHBb7V27h4a)_