### PR TITLE
Support wrapped JSON submissions

### DIFF
--- a/frontend/src/landing_page/landing_page_components/submissionFormatUtils.js
+++ b/frontend/src/landing_page/landing_page_components/submissionFormatUtils.js
@@ -67,9 +67,12 @@ export const buildQuestionsExport = ({
 export const normalizeParsedSubmissionJson = (parsed) => {
   let modelResults = [];
   let ids = [];
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : (Array.isArray(parsed?.predictions) ? parsed.predictions : parsed?.outputs);
 
-  if (Array.isArray(parsed)) {
-    parsed.forEach((item, idx) => {
+  if (Array.isArray(rows)) {
+    rows.forEach((item, idx) => {
       const output = item.output ?? item.prediction ?? item.translation ?? item.answer ?? item.result ?? "";
       const rawId = item.id ?? item.sentence_id ?? idx;
       const numId = Number(rawId);
@@ -80,7 +83,7 @@ export const normalizeParsedSubmissionJson = (parsed) => {
     modelResults = parsed.modelResults;
     ids = parsed.sentence_ids;
   } else {
-    throw new Error("Unrecognized JSON format. Expected array of {id, output} or {modelResults, sentence_ids}.");
+    throw new Error("Unrecognized JSON format. Expected array of {id, output}, {predictions: [...]}, {outputs: [...]}, or {modelResults, sentence_ids}.");
   }
 
   return { modelResults, sentenceIds: ids };

--- a/frontend/src/landing_page/landing_page_components/submissionFormatUtils.test.js
+++ b/frontend/src/landing_page/landing_page_components/submissionFormatUtils.test.js
@@ -53,6 +53,34 @@ describe("submission format helpers", () => {
     });
   });
 
+  test("normalizeParsedSubmissionJson accepts predictions wrapper", () => {
+    const parsed = normalizeParsedSubmissionJson({
+      predictions: [
+        { id: 9, output: "A" },
+        { id: 10, prediction: "B" },
+      ],
+    });
+
+    expect(parsed).toEqual({
+      modelResults: ["A", "B"],
+      sentenceIds: [9, 10],
+    });
+  });
+
+  test("normalizeParsedSubmissionJson accepts outputs wrapper", () => {
+    const parsed = normalizeParsedSubmissionJson({
+      outputs: [
+        { sentence_id: "2", answer: "supported" },
+        { sentence_id: "3", result: "refuted" },
+      ],
+    });
+
+    expect(parsed).toEqual({
+      modelResults: ["supported", "refuted"],
+      sentenceIds: [2, 3],
+    });
+  });
+
   test("normalizeParsedSubmissionJson accepts submit_model body shape", () => {
     const parsed = normalizeParsedSubmissionJson({
       modelResults: ["yes", "no"],


### PR DESCRIPTION
## Summary
- Accept JSON uploads wrapped in a top-level `predictions` array.
- Accept JSON uploads wrapped in a top-level `outputs` array.
- Add focused tests for both wrapper formats.

## Why
This makes the submission upload flow more forgiving for common model output formats while preserving the existing supported shapes:
- raw array of `{ id, output }`
- `{ modelResults, sentence_ids }`

## Test
- `npm test -- --watchAll=false --runTestsByPath src/landing_page/landing_page_components/submissionFormatUtils.test.js`

## Notes
No backend scoring behavior changed. This only normalizes additional frontend JSON upload shapes into the existing `modelResults` and `sentenceIds` format.