### PR TITLE
Add model cards and submission example results

### DIFF
--- a/backend/blueprints/submissions.py
+++ b/backend/blueprints/submissions.py
@@ -784,6 +784,94 @@ def submission_detail(submission_id: int):
     })
 
 
+@bp.get("/public/submissions/<int:submission_id>/examples")
+def submission_examples(submission_id: int):
+    """Per-example prediction results for a submission.
+
+    Query params:
+      filter  = all | correct | wrong   (default: all)
+      offset  = int (default 0)
+      limit   = int 1–500 (default 100)
+    """
+    sub, err = _require_submission_owner(request, submission_id)
+    if err:
+        return err
+
+    filter_by = request.args.get("filter", "all").lower()
+    if filter_by not in ("all", "correct", "wrong"):
+        return jsonify({"success": False, "error": "filter must be all, correct, or wrong"}), 400
+    try:
+        offset = max(0, int(request.args.get("offset", 0)))
+        limit = min(500, max(1, int(request.args.get("limit", 100))))
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "error": "offset and limit must be integers"}), 400
+
+    conn, cursor = get_db_connection()
+    if conn and cursor:
+        try:
+            try:
+                cursor.execute(
+                    "SELECT ms.submitter_id, ms.submitted_by, er.evaluation_details "
+                    "FROM model_submissions ms "
+                    "JOIN evaluation_results er ON er.model_submission_id = ms.id "
+                    "WHERE ms.id = %s",
+                    (submission_id,),
+                )
+            except Exception:
+                cursor.execute(
+                    "SELECT ms.submitted_by, er.evaluation_details "
+                    "FROM model_submissions ms "
+                    "JOIN evaluation_results er ON er.model_submission_id = ms.id "
+                    "WHERE ms.id = %s",
+                    (submission_id,),
+                )
+            r = cursor.fetchone()
+        finally:
+            try:
+                cursor.close()
+                conn.close()
+            except Exception:
+                pass
+        if not r:
+            return jsonify({"success": False, "error": "Not found"}), 404
+        owner = r.get("submitter_id") or r.get("submitted_by") or ""
+        if owner != sub:
+            return jsonify({"success": False, "error": "Forbidden"}), 403
+        raw_det = r.get("evaluation_details") or "{}"
+    else:
+        sub_row = next((s for s in _STORE["submissions"] if s["id"] == submission_id), None)
+        if not sub_row:
+            return jsonify({"success": False, "error": "Not found"}), 404
+        owner = sub_row.get("submitter_id") or sub_row.get("submitted_by")
+        if owner != sub:
+            return jsonify({"success": False, "error": "Forbidden"}), 403
+        ev = next((e for e in _STORE["evaluations"] if e["submission_id"] == submission_id), None)
+        raw_det = (ev or {}).get("evaluation_details") or "{}"
+
+    try:
+        det = json.loads(raw_det) if isinstance(raw_det, str) else (raw_det or {})
+    except Exception:
+        det = {}
+
+    all_items: List[Dict[str, Any]] = det.get("item_results") or []
+    if filter_by == "correct":
+        all_items = [it for it in all_items if it.get("correct") is True]
+    elif filter_by == "wrong":
+        all_items = [it for it in all_items if it.get("correct") is False]
+
+    total = len(all_items)
+    page = all_items[offset: offset + limit]
+    return jsonify({
+        "success": True,
+        "submission_id": submission_id,
+        "filter": filter_by,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "examples": page,
+    })
+
+
 def _require_submission_owner(request, submission_id: int):
     """Return (sub, error_response) — sub is the authenticated identity, error_response is None on success."""
     sub = jwt_sub_from_request(request)

--- a/backend/eval_core/hf_dataset_recipes.py
+++ b/backend/eval_core/hf_dataset_recipes.py
@@ -234,7 +234,7 @@ def load_conll2003_ground_truth(
     split: str,
     limit: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
-    ds = _load_dataset(CONLL_HF_ID, split=split, trust_remote_code=True)
+    ds = _load_dataset(CONLL_HF_ID, split=split)
     ner_feature = ds.features["ner_tags"]
     tag_names = list(ner_feature.feature.names)
     n = len(ds)

--- a/backend/eval_core/leaderboard_bridge.py
+++ b/backend/eval_core/leaderboard_bridge.py
@@ -192,6 +192,57 @@ def _bootstrap_ci(
     return scores[lo], scores[min(hi, len(scores) - 1)]
 
 
+_BINARY_CORRECT_TASKS = frozenset({
+    "text_classification",
+    "named_entity_recognition",
+    "document_qa",
+    "line_qa",
+    "multiple_choice_qa",
+    "math_reasoning",
+    "natural_language_inference",
+    "fact_verification",
+    "semantic_similarity",
+    "code_generation",
+    "summarization",
+    "retrieval",
+    "dialogue",
+})
+
+
+def _build_item_results(
+    gt: List[Dict[str, Any]],
+    preds: List[Dict[str, Any]],
+    task_norm: str,
+) -> List[Dict[str, Any]]:
+    """Return per-example {id, ground_truth, prediction, correct} rows."""
+    pred_map = {p["id"]: p["prediction"] for p in preds}
+    can_score = task_norm in _BINARY_CORRECT_TASKS
+    items: List[Dict[str, Any]] = []
+    for g in gt:
+        gid = g["id"]
+        answer = g.get("answer")
+        pred = pred_map.get(gid)
+        if can_score and pred is not None:
+            if isinstance(answer, list):
+                acceptable = [str(a).strip().lower() for a in answer if a is not None]
+            else:
+                acceptable = [str(answer).strip().lower()]
+            pred_norm = (
+                str(pred[0]).strip().lower() if isinstance(pred, list) and pred
+                else str(pred).strip().lower()
+            )
+            correct: Optional[bool] = pred_norm in acceptable
+        else:
+            correct = None
+        items.append({
+            "id": gid,
+            "ground_truth": answer,
+            "prediction": pred,
+            "correct": correct,
+        })
+    return items
+
+
 def run_personal_eval(
     task_type_raw: Optional[str],
     evaluation_metric: Optional[str],
@@ -221,6 +272,7 @@ def run_personal_eval(
         detailed["ci_low"] = round(ci[0], 6)
         detailed["ci_high"] = round(ci[1], 6)
         detailed["ci_level"] = 0.95
+    detailed["item_results"] = _build_item_results(gt, preds, tt)
     return float(score), detailed
 
 

--- a/backend/examples/seed_hf_benchmarks.py
+++ b/backend/examples/seed_hf_benchmarks.py
@@ -164,7 +164,7 @@ def _load_conll2003(limit: int = 500) -> None:
     """CoNLL-2003 English NER validation split."""
     name = "CoNLL-2003 NER"
     print(f"\nLoading {name}…")
-    ds = load_dataset("conll2003", split="validation", trust_remote_code=True)
+    ds = load_dataset("conll2003", split="validation")
     ner_feature = ds.features["ner_tags"]
     tag_names = list(ner_feature.feature.names)
 

--- a/backend/tests/test_audit_regressions.py
+++ b/backend/tests/test_audit_regressions.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 try:
     import app as app_module
     from blueprints import auth as auth_module
@@ -7,6 +9,7 @@ except ImportError:  # pragma: no cover
 
 
 app = app_module.app
+BACKEND_DIR = Path(__file__).resolve().parents[1]
 
 
 def reset_state():
@@ -45,6 +48,17 @@ def test_run_csv_benchmarks_rejects_malformed_sample_size(monkeypatch):
     assert response.status_code == 400
     assert response.is_json
     assert response.get_json()["error"] == "sample_size must be an integer"
+
+
+def test_hf_dataset_loading_does_not_enable_remote_code_by_default():
+    checked_files = [
+        BACKEND_DIR / "eval_core" / "hf_dataset_recipes.py",
+        BACKEND_DIR / "examples" / "seed_hf_benchmarks.py",
+    ]
+
+    for path in checked_files:
+        source = path.read_text(encoding="utf-8")
+        assert "trust_remote_code=True" not in source
 
 
 def test_submit_model_db_write_failure_does_not_fallback_to_memory(monkeypatch):

--- a/frontend/src/constants/RouteConstants.js
+++ b/frontend/src/constants/RouteConstants.js
@@ -12,3 +12,4 @@ export const csvBenchmarksPath = "/benchmarks";
 export const addDatasetPath = "/datasets/new";
 export const createLeaderboardPath = "/create-leaderboard";
 export const compareModelsPath = "/compare";
+export const modelCardPath = "/model/:name";

--- a/frontend/src/landing_page/LandingPage.js
+++ b/frontend/src/landing_page/LandingPage.js
@@ -20,9 +20,10 @@ import RequestDataset from "./landing_page_components/RequestDataset";
 import AdminDatasetRequests from "./landing_page_components/AdminDatasetRequests";
 import AddDataset from "./landing_page_components/AddDataset";
 import DatasetDetails from "./landing_page_components/DatasetDetails";
-import { submittoleaderboardPath, mySubmissionsPath, adminLeaderboardPath, adminSubmissionsPath, adminDatasetRequestsPath, requestDatasetPath, csvBenchmarksPath, addDatasetPath, loginPath, oauthCallbackPath, createLeaderboardPath, compareModelsPath } from "../constants/RouteConstants";
+import { submittoleaderboardPath, mySubmissionsPath, adminLeaderboardPath, adminSubmissionsPath, adminDatasetRequestsPath, requestDatasetPath, csvBenchmarksPath, addDatasetPath, loginPath, oauthCallbackPath, createLeaderboardPath, compareModelsPath, modelCardPath } from "../constants/RouteConstants";
 import MySubmissions from "./landing_page_components/MySubmissions";
 import ModelComparison from "./landing_page_components/ModelComparison";
+import ModelCard from "./landing_page_components/ModelCard";
 import HeaderBar from "./landing_page_components/HeaderBar";
 import AuthGuard from "./landing_page_components/AuthGuard";
 import LoginPage from "./landing_page_components/LoginPage";
@@ -81,6 +82,7 @@ function LandingPage() {
           <Route path={createLeaderboardPath} index element={<AuthGuard><CreateLeaderboardFromHF /></AuthGuard>} />,
           <Route path="/dataset/:name" element={<DatasetDetails />} />,
           <Route path={compareModelsPath} element={<ModelComparison />} />,
+          <Route path={modelCardPath} element={<ModelCard />} />,
           <Route path={requestDatasetPath} index element={<RequestDataset />} />,
           <Route path={adminLeaderboardPath} index element={<AuthGuard><AdminLeaderboardManager /></AuthGuard>} />,
           <Route path={adminSubmissionsPath} index element={<AuthGuard><AdminSubmissionsModeration /></AuthGuard>} />,

--- a/frontend/src/landing_page/landing_page_components/DatasetDetails.js
+++ b/frontend/src/landing_page/landing_page_components/DatasetDetails.js
@@ -184,7 +184,15 @@ const DatasetDetails = () => {
                   </div>
                   {data.top_models.map((m, i) => (
                     <div key={i} className="grid grid-cols-3 text-center px-3 py-2 text-white text-sm">
-                      <div className="truncate" title={m.model}>{m.model}</div>
+                      <div className="truncate" title={m.model}>
+                        <button
+                          type="button"
+                          className="truncate max-w-full text-[#defe47] hover:underline"
+                          onClick={() => navigate(`/model/${encodeURIComponent(m.model)}`)}
+                        >
+                          {m.model}
+                        </button>
+                      </div>
                       <div className="tabular-nums">
                         {typeof m.score === 'number' ? (m.score < 1 ? m.score.toFixed(4) : m.score.toFixed(2)) : m.score}
                       </div>

--- a/frontend/src/landing_page/landing_page_components/Leaderboard.js
+++ b/frontend/src/landing_page/landing_page_components/Leaderboard.js
@@ -1963,12 +1963,17 @@ const Leaderboard = () => {
                           </div>
                         </td>
                         <td className="px-2 py-2.5 min-w-[9rem] max-w-xs">
-                          <div
-                            className={["font-medium truncate", isTop ? "text-white" : "text-gray-300"].join(" ")}
+                          <button
+                            type="button"
+                            className={[
+                              "font-medium truncate max-w-full text-left hover:text-[#defe47] hover:underline",
+                              isTop ? "text-white" : "text-gray-300",
+                            ].join(" ")}
                             title={model.model}
+                            onClick={() => navigate(`/model/${encodeURIComponent(model.model)}`)}
                           >
                             {model.model}
-                          </div>
+                          </button>
                         </td>
                         <td className="px-5 py-2.5 text-right">
                           <span

--- a/frontend/src/landing_page/landing_page_components/ModelCard.js
+++ b/frontend/src/landing_page/landing_page_components/ModelCard.js
@@ -1,0 +1,265 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
+
+function decodeParam(value) {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function formatMetricKey(metric) {
+  if (!metric) return "Score";
+  return String(metric)
+    .replace(/_/g, " ")
+    .replace(/\b([a-z])/g, (c) => c.toUpperCase());
+}
+
+function formatScore(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return "N/A";
+  if (n >= 0 && n <= 1) return (n * 100).toFixed(1);
+  return n.toFixed(Math.abs(n) < 1 ? 3 : 1);
+}
+
+function formatDate(value) {
+  if (!value) return "Unknown";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return d.toLocaleDateString();
+}
+
+function inferProvider(modelName) {
+  const name = String(modelName || "").toLowerCase();
+  if (name.includes("gpt") || name.includes("openai")) return "OpenAI";
+  if (name.includes("claude") || name.includes("anthropic")) return "Anthropic";
+  if (name.includes("gemini") || name.includes("palm")) return "Google";
+  if (name.includes("llama") || name.includes("meta-")) return "Meta";
+  if (name.includes("mistral") || name.includes("mixtral")) return "Mistral";
+  if (name.includes("qwen")) return "Alibaba";
+  if (name.includes("phi")) return "Microsoft";
+  if (name.includes("gemma")) return "Google DeepMind";
+  return "Unknown";
+}
+
+function aggregateModel(entries, modelName) {
+  const target = String(modelName || "").toLowerCase();
+  const rows = (entries || [])
+    .filter((entry) => String(entry.model_name || "").toLowerCase() === target)
+    .map((entry) => ({
+      ...entry,
+      display_score:
+        typeof entry.composite_score === "number"
+          ? entry.composite_score
+          : Number(entry.score),
+    }))
+    .sort((a, b) => Number(b.display_score || 0) - Number(a.display_score || 0));
+
+  const best = rows[0];
+  const latest = rows
+    .filter((row) => row.submitted_at)
+    .sort((a, b) => new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime())[0];
+  const submitters = Array.from(new Set(rows.map((row) => row.submitted_by).filter(Boolean)));
+  const taskTypes = Array.from(new Set(rows.map((row) => row.task_type).filter(Boolean)));
+  const sources = Array.from(
+    new Set(rows.map((row) => row.metadata?.source || (Number(row.submission_id) < 0 ? "Seeded benchmark" : "User submission")).filter(Boolean))
+  );
+
+  return {
+    rows,
+    best,
+    latest,
+    submitters,
+    taskTypes,
+    sources,
+    provider: inferProvider(modelName),
+  };
+}
+
+const ModelCard = () => {
+  const { name } = useParams();
+  const navigate = useNavigate();
+  const modelName = useMemo(() => decodeParam(name), [name]);
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let ignore = false;
+    const run = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        let cursor = "";
+        const allEntries = [];
+        for (let page = 0; page < 20; page += 1) {
+          const url = new URL(`${API_BASE}/public/get_leaderboard`);
+          url.searchParams.set("page_size", "100");
+          if (cursor) url.searchParams.set("cursor", cursor);
+          const res = await fetch(url.toString());
+          const json = await res.json();
+          if (!res.ok || json.success !== true) throw new Error(json.error || "Failed to load leaderboard");
+          allEntries.push(...(Array.isArray(json.leaderboard) ? json.leaderboard : []));
+          cursor = json.next_cursor || "";
+          if (!cursor) break;
+        }
+        if (!ignore) setEntries(allEntries);
+      } catch (e) {
+        if (!ignore) setError(e.message || "Error loading model card");
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    };
+    if (modelName) run();
+    else setLoading(false);
+    return () => {
+      ignore = true;
+    };
+  }, [modelName]);
+
+  const card = useMemo(() => aggregateModel(entries, modelName), [entries, modelName]);
+  const metricKeys = useMemo(() => {
+    const keys = new Set();
+    card.rows.forEach((row) => {
+      Object.entries(row.detailed_scores || {}).forEach(([key, value]) => {
+        if (typeof value === "number" && !["ci_low", "ci_high"].includes(key)) keys.add(key);
+      });
+    });
+    return Array.from(keys).slice(0, 6);
+  }, [card.rows]);
+
+  return (
+    <div className="flex flex-col items-center justify-start min-h-screen bg-gray-900 pb-24 mx-3">
+      <div className="w-full max-w-6xl mt-6 flex justify-between gap-3">
+        <button type="button" onClick={() => navigate("/")} className="px-3 py-1 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-700/40">
+          Back to leaderboard
+        </button>
+        <button type="button" onClick={() => navigate("/compare")} className="px-3 py-1 rounded-md border border-[#defe47]/40 text-[#defe47] hover:bg-[#defe47]/10">
+          Compare models
+        </button>
+      </div>
+
+      <div className="w-full max-w-6xl bg-gray-900/70 rounded-xl border border-gray-800 p-6 mt-3">
+        {loading ? (
+          <div className="text-gray-300">Loading model card...</div>
+        ) : error ? (
+          <div className="text-red-400">{error}</div>
+        ) : card.rows.length === 0 ? (
+          <div>
+            <h1 className="text-2xl font-bold text-white">{modelName}</h1>
+            <p className="text-gray-400 mt-3">No public leaderboard submissions were found for this model.</p>
+          </div>
+        ) : (
+          <div>
+            <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-5">
+              <div>
+                <div className="text-xs uppercase tracking-widest text-gray-500">Model card</div>
+                <h1 className="text-3xl font-bold text-white mt-1 break-words">{modelName}</h1>
+                <div className="flex flex-wrap gap-2 mt-3">
+                  <span className="px-2.5 py-1 rounded-full border border-gray-700 bg-gray-950 text-gray-300 text-xs">Provider: {card.provider}</span>
+                  {card.taskTypes.map((task) => (
+                    <span key={task} className="px-2.5 py-1 rounded-full border border-blue-400/30 bg-blue-500/10 text-blue-200 text-xs">
+                      {formatMetricKey(task)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3 min-w-full lg:min-w-[34rem]">
+                <div className="border border-gray-800 rounded-lg bg-gray-950 p-3">
+                  <div className="text-gray-500 text-xs">Best score</div>
+                  <div className="text-[#defe47] text-2xl font-semibold tabular-nums">{formatScore(card.best.display_score)}</div>
+                </div>
+                <div className="border border-gray-800 rounded-lg bg-gray-950 p-3">
+                  <div className="text-gray-500 text-xs">Benchmarks</div>
+                  <div className="text-white text-2xl font-semibold tabular-nums">{card.rows.length}</div>
+                </div>
+                <div className="border border-gray-800 rounded-lg bg-gray-950 p-3">
+                  <div className="text-gray-500 text-xs">Best rank</div>
+                  <div className="text-white text-2xl font-semibold tabular-nums">#{card.best.rank || "N/A"}</div>
+                </div>
+                <div className="border border-gray-800 rounded-lg bg-gray-950 p-3">
+                  <div className="text-gray-500 text-xs">Latest run</div>
+                  <div className="text-white text-sm font-semibold mt-1">{formatDate(card.latest?.submitted_at)}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-6">
+              <div className="border border-gray-800 rounded-lg bg-black/20 p-4">
+                <div className="text-white font-semibold">Attribution</div>
+                <div className="text-gray-300 text-sm mt-2">{card.submitters.length ? card.submitters.join(", ") : "Not provided"}</div>
+              </div>
+              <div className="border border-gray-800 rounded-lg bg-black/20 p-4">
+                <div className="text-white font-semibold">Result source</div>
+                <div className="text-gray-300 text-sm mt-2">{card.sources.join(", ")}</div>
+              </div>
+              <div className="border border-gray-800 rounded-lg bg-black/20 p-4">
+                <div className="text-white font-semibold">Best benchmark</div>
+                <button
+                  type="button"
+                  className="text-[#defe47] text-sm mt-2 text-left underline"
+                  onClick={() => navigate(`/dataset/${encodeURIComponent(card.best.dataset_name)}`)}
+                >
+                  {card.best.dataset_name}
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-7">
+              <div className="text-white font-semibold mb-3">Benchmark results</div>
+              <div className="overflow-x-auto border border-gray-800 rounded-lg">
+                <table className="w-full border-collapse text-sm">
+                  <thead className="bg-gray-950 text-gray-400">
+                    <tr>
+                      <th className="text-left px-3 py-2">Dataset</th>
+                      <th className="text-left px-3 py-2">Task</th>
+                      <th className="text-right px-3 py-2">Rank</th>
+                      <th className="text-right px-3 py-2">Score</th>
+                      <th className="text-left px-3 py-2">Primary metric</th>
+                      {metricKeys.map((key) => (
+                        <th key={key} className="text-right px-3 py-2">{formatMetricKey(key)}</th>
+                      ))}
+                      <th className="text-left px-3 py-2">Submitted</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-800">
+                    {card.rows.map((row) => (
+                      <tr key={`${row.dataset_name}-${row.submission_id || row.rank}`} className="text-gray-200 hover:bg-white/[0.03]">
+                        <td className="px-3 py-2">
+                          <button
+                            type="button"
+                            className="text-[#defe47] underline text-left"
+                            onClick={() => navigate(`/dataset/${encodeURIComponent(row.dataset_name)}`)}
+                          >
+                            {row.dataset_name}
+                          </button>
+                        </td>
+                        <td className="px-3 py-2 text-gray-300">{formatMetricKey(row.task_type)}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">#{row.rank || "N/A"}</td>
+                        <td className="px-3 py-2 text-right text-[#defe47] font-semibold tabular-nums">{formatScore(row.display_score)}</td>
+                        <td className="px-3 py-2 text-gray-300">{formatMetricKey(row.primary_metric || row.evaluation_metric)}</td>
+                        {metricKeys.map((key) => (
+                          <td key={key} className="px-3 py-2 text-right tabular-nums text-gray-300">
+                            {typeof row.detailed_scores?.[key] === "number" ? formatScore(row.detailed_scores[key]) : "N/A"}
+                          </td>
+                        ))}
+                        <td className="px-3 py-2 text-gray-400">{formatDate(row.submitted_at)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ModelCard;


### PR DESCRIPTION
## Summary
This PR improves leaderboard transparency by making it easier to move from a high-level ranking into model-level and submission-level evidence. Users can now click a model name to open a structured model card, and the backend now preserves per-example evaluation artifacts so submission detail/error-analysis views can show which examples were correct or wrong.

## What Changed
- Added model card pages at `/model/:name`.
- Linked model names from the main leaderboard and dataset detail views into the new model card route.
- Aggregated public leaderboard rows on each model card to show best score, benchmark count, best rank, latest run, submitter attribution, result source, inferred provider, best benchmark, and per-benchmark metrics.
- Added `item_results` to evaluation details so each evaluated example can include its id, prediction, ground truth, and correctness when the task supports exact-style correctness.
- Added `GET /public/submissions/<submission_id>/examples` for owner-scoped, paginated example inspection with `filter=all|correct|wrong`.
- Removed default Hugging Face `trust_remote_code=True` from CoNLL dataset loading and added a regression check so it is not reintroduced silently.

## User Impact
- Reviewers and users can inspect a model beyond a single leaderboard row.
- Model performance becomes easier to compare across datasets because model cards collect the relevant public benchmark results in one place.
- Submission owners get a backend path for error analysis, enabling future UI work around example-level failures and wins.

## Notes
- The model card uses existing public leaderboard data, so this does not require a new model metadata table or migration.
- Provider is inferred from the model name as a lightweight first pass; richer model metadata can be layered on later.
- Per-example correctness is only marked when the task can be scored with the current exact-style comparison. Otherwise correctness is returned as `null`.

## Verification
- `npm run lint`
- `npm run build`
- `.venv/bin/pytest -q backend/tests/test_audit_regressions.py`

Local `ruff` was not available in this environment.