### PR TITLE
Add FAQ page and metric definition tooltips

### DIFF
--- a/frontend/src/constants/RouteConstants.js
+++ b/frontend/src/constants/RouteConstants.js
@@ -13,3 +13,4 @@ export const addDatasetPath = "/datasets/new";
 export const createLeaderboardPath = "/create-leaderboard";
 export const compareModelsPath = "/compare";
 export const modelCardPath = "/model/:name";
+export const faqPath = "/faq";

--- a/frontend/src/landing_page/LandingPage.js
+++ b/frontend/src/landing_page/LandingPage.js
@@ -20,7 +20,7 @@ import RequestDataset from "./landing_page_components/RequestDataset";
 import AdminDatasetRequests from "./landing_page_components/AdminDatasetRequests";
 import AddDataset from "./landing_page_components/AddDataset";
 import DatasetDetails from "./landing_page_components/DatasetDetails";
-import { submittoleaderboardPath, mySubmissionsPath, adminLeaderboardPath, adminSubmissionsPath, adminDatasetRequestsPath, requestDatasetPath, csvBenchmarksPath, addDatasetPath, loginPath, oauthCallbackPath, createLeaderboardPath, compareModelsPath, modelCardPath } from "../constants/RouteConstants";
+import { submittoleaderboardPath, mySubmissionsPath, adminLeaderboardPath, adminSubmissionsPath, adminDatasetRequestsPath, requestDatasetPath, csvBenchmarksPath, addDatasetPath, loginPath, oauthCallbackPath, createLeaderboardPath, compareModelsPath, modelCardPath, faqPath } from "../constants/RouteConstants";
 import MySubmissions from "./landing_page_components/MySubmissions";
 import ModelComparison from "./landing_page_components/ModelComparison";
 import ModelCard from "./landing_page_components/ModelCard";
@@ -29,6 +29,7 @@ import AuthGuard from "./landing_page_components/AuthGuard";
 import LoginPage from "./landing_page_components/LoginPage";
 import OAuthCallback from "./landing_page_components/OAuthCallback";
 import CreateLeaderboardFromHF from "./landing_page_components/CreateLeaderboardFromHF";
+import FAQ from "./landing_page_components/FAQ";
 
 function LandingPage() {
   const location = useLocation();
@@ -83,6 +84,7 @@ function LandingPage() {
           <Route path="/dataset/:name" element={<DatasetDetails />} />,
           <Route path={compareModelsPath} element={<ModelComparison />} />,
           <Route path={modelCardPath} element={<ModelCard />} />,
+          <Route path={faqPath} element={<FAQ />} />,
           <Route path={requestDatasetPath} index element={<RequestDataset />} />,
           <Route path={adminLeaderboardPath} index element={<AuthGuard><AdminLeaderboardManager /></AuthGuard>} />,
           <Route path={adminSubmissionsPath} index element={<AuthGuard><AdminSubmissionsModeration /></AuthGuard>} />,

--- a/frontend/src/landing_page/landing_page_components/FAQ.js
+++ b/frontend/src/landing_page/landing_page_components/FAQ.js
@@ -1,0 +1,138 @@
+import { useState } from "react";
+
+const FAQ_ITEMS = [
+  {
+    question: "How is this different from MMLU, HELM, BIG-Bench, or Chatbot Arena?",
+    answer:
+      "Those benchmarks test general capability on academic tasks. Anote tests performance on your specific task and data. A model that scores 90% on MMLU might score 60% on your customer support classification problem. The only way to know is to test on your data. Anote lets you benchmark any model against real-world datasets — including your own — so the results are directly actionable.",
+  },
+  {
+    question: "How do I know the results are accurate?",
+    answer:
+      "Every benchmark result is reproducible. Prompts are constructed deterministically from the dataset, model outputs are collected via the provider's API, and scores are computed with established metrics (accuracy, F1, BLEU, BERTScore). The scoring code is open source so you can inspect it. For translation tasks, we use BERTScore for Asian languages (Japanese, Chinese, Korean) where BLEU is unreliable, and BLEU for Spanish and Arabic where n-gram overlap is meaningful.",
+  },
+  {
+    question: "Can someone game the leaderboard?",
+    answer:
+      "Dataset inputs are public — there is no hidden test set. Anote is not a competition leaderboard; it's a benchmarking platform. You run your model against a dataset and see where it ranks compared to others who ran against the same dataset. If you fine-tune on the benchmark data, your score will reflect that, but a careful reader will notice the submission name and draw their own conclusions.",
+  },
+  {
+    question: "Which metric should I use for my task?",
+    answer: (
+      <ul className="space-y-1.5 mt-1">
+        <li><span className="text-gray-200 font-medium">Text classification</span> — Accuracy (overall correctness) or F1 (balances precision and recall, better when classes are unequal)</li>
+        <li><span className="text-gray-200 font-medium">Translation (Spanish, Arabic)</span> — BLEU (measures n-gram overlap with a reference translation; 0–1, higher is better)</li>
+        <li><span className="text-gray-200 font-medium">Translation (Japanese, Chinese, Korean)</span> — BERTScore (semantic similarity using embeddings; n-gram overlap is meaningless for these scripts)</li>
+        <li><span className="text-gray-200 font-medium">Q&A / document retrieval</span> — Exact Match or BERTScore depending on whether answers are expected to match word-for-word or semantically</li>
+        <li><span className="text-gray-200 font-medium">Summarization</span> — ROUGE-L (longest common subsequence overlap with a reference summary)</li>
+      </ul>
+    ),
+  },
+  {
+    question: "How do I submit my own model?",
+    answer: (
+      <ol className="space-y-1.5 mt-1 list-decimal list-inside">
+        <li>Go to <span className="text-[#28b2fb]">Submit</span> in the navigation bar and log in.</li>
+        <li>Choose a benchmark dataset from the dropdown.</li>
+        <li>Select your model provider (OpenAI, Anthropic, Google, Ollama, or a custom endpoint) and enter credentials if required.</li>
+        <li>Submit — the platform runs your model against the dataset and scores it automatically.</li>
+        <li>Your result appears in the leaderboard under the dataset you chose.</li>
+      </ol>
+    ),
+  },
+  {
+    question: "What is BERTScore and why is it better than BLEU for some languages?",
+    answer:
+      "BLEU counts exact n-gram matches between a model's output and a reference. It works well for European languages because similar meanings often use the same words. For Japanese, Chinese, and Korean, word segmentation is ambiguous and characters carry more meaning than individual words, so n-gram overlap is nearly zero even for good translations. BERTScore instead computes the cosine similarity of contextual embeddings (from a multilingual BERT model), which captures semantic meaning regardless of the surface form. Scores are between 0 and 1; values above 0.85 are generally considered high quality.",
+  },
+  {
+    question: "Where can I find the evaluation datasets?",
+    answer:
+      "Each dataset card in the leaderboard includes a link to the source (HuggingFace, GitHub, or the original paper). You can also import datasets directly from HuggingFace Hub using the Create Leaderboard feature. If you need direct access to a dataset that isn't linked, email nvidra@anote.ai.",
+  },
+  {
+    question: "How many times can I submit?",
+    answer:
+      "There is no strict limit. You're welcome to submit as many times as you like, but for the most meaningful comparison, submit when there are substantial updates or improvements to your model.",
+  },
+  {
+    question: "Do I need to share my model weights?",
+    answer:
+      "No. You only need to provide a way for the platform to run inference — either by selecting a hosted provider (OpenAI, Anthropic, Google) and providing your API key, or by pointing to a local Ollama endpoint. Model weights, code, and training data are never required.",
+  },
+];
+
+function ChevronIcon({ open }) {
+  return (
+    <svg
+      className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
+export default function FAQ() {
+  const [openIndex, setOpenIndex] = useState(null);
+
+  const toggle = (i) => setOpenIndex(openIndex === i ? null : i);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-2xl font-bold text-white mb-2">Frequently Asked Questions</h1>
+      <p className="text-gray-400 mb-8 text-sm">
+        Why trust these results? How do we differ from MMLU and HELM? Which metric should you use?
+      </p>
+
+      <div className="space-y-2">
+        {FAQ_ITEMS.map((item, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-gray-800/60 bg-gray-900/40 overflow-hidden"
+          >
+            <button
+              type="button"
+              className="w-full flex items-center justify-between gap-4 px-5 py-4 text-left"
+              onClick={() => toggle(i)}
+              aria-expanded={openIndex === i}
+            >
+              <span className="text-sm font-medium text-gray-200">{item.question}</span>
+              <ChevronIcon open={openIndex === i} />
+            </button>
+            {openIndex === i && (
+              <div className="px-5 pb-5 text-sm text-gray-400 leading-relaxed border-t border-gray-800/40 pt-3">
+                {item.answer}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-10 rounded-xl border border-[#28b2fb]/20 bg-[#28b2fb]/5 px-5 py-4">
+        <p className="text-sm text-gray-300">
+          Still have questions?{" "}
+          <a
+            href="mailto:nvidra@anote.ai"
+            className="text-[#28b2fb] hover:underline"
+          >
+            Email us
+          </a>{" "}
+          or{" "}
+          <a
+            href="https://anote.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#28b2fb] hover:underline"
+          >
+            visit anote.ai
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/landing_page/landing_page_components/HeaderBar.js
+++ b/frontend/src/landing_page/landing_page_components/HeaderBar.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
+  faqPath,
   loginPath,
   mySubmissionsPath,
   requestDatasetPath,
@@ -23,6 +24,7 @@ export default function HeaderBar() {
     { label: 'Submit', path: submittoleaderboardPath },
     { label: 'My submissions', path: mySubmissionsPath },
     { label: 'Request dataset', path: requestDatasetPath },
+    { label: 'FAQ', path: faqPath },
   ];
 
   const signedInWithJwt = authRev >= 0 && !!getLeaderboardJwt();

--- a/frontend/src/landing_page/landing_page_components/Leaderboard.js
+++ b/frontend/src/landing_page/landing_page_components/Leaderboard.js
@@ -12,6 +12,32 @@ function humanizeMetricKey(metric) {
     .replace(/\b([a-z])/g, (c) => c.toUpperCase());
 }
 
+const METRIC_DESCRIPTIONS = {
+  accuracy: "Percentage of predictions that exactly match the correct label. Simple and intuitive: 0.90 means 90 out of 100 answers were right.",
+  f1: "Harmonic mean of precision (how many predicted positives were correct) and recall (how many actual positives were found). Better than accuracy when classes are unequal.",
+  f1_macro: "F1 averaged equally across all classes, regardless of how often each class appears. Useful when you care equally about every category.",
+  f1_micro: "F1 computed globally across all examples — favors performance on frequent classes.",
+  f1_weighted: "F1 averaged across classes, weighted by how often each class appears in the dataset.",
+  bleu: "Measures how closely model output matches a reference translation word-for-word (n-gram overlap). Range 0–1; higher is better. Reliable for European languages; unreliable for Japanese, Chinese, Korean.",
+  bertscore: "Measures semantic similarity between model output and a reference using contextual embeddings. Captures meaning even when wording differs. Range ~0.8–1.0 for good translations; much more reliable than BLEU for Asian scripts.",
+  rouge_l: "Longest Common Subsequence overlap between a generated summary and a reference. Captures fluency and coverage. Range 0–1; higher is better.",
+  exact_match: "1 if the predicted answer exactly matches the reference (after normalization), 0 otherwise. Strict but unambiguous.",
+  retrieval_accuracy: "Fraction of queries where the correct document or passage was retrieved in the top result. Higher is better.",
+  mrr: "Mean Reciprocal Rank — averages 1/rank of the first correct result across queries. A score of 1.0 means the correct answer was always ranked first.",
+  "mrr@10": "Mean Reciprocal Rank considering only the top 10 retrieved results. Common in information retrieval evaluation.",
+  spearman: "Spearman rank correlation between predicted scores and human judgments. Range −1 to 1; values above 0.7 are considered strong agreement.",
+  pass_at_1: "Fraction of coding problems solved correctly on the first attempt. Standard metric for code generation benchmarks.",
+  "pass@1": "Fraction of coding problems solved correctly on the first attempt. Standard metric for code generation benchmarks.",
+  median_distance_error: "Median geographic distance (in km) between the predicted location and the true location. Lower is better.",
+  inform_rate: "In dialogue systems: fraction of turns where the model correctly provided the information the user requested.",
+};
+
+function metricDescription(metric) {
+  if (!metric) return null;
+  const key = String(metric).toLowerCase().trim().replace(/\s+/g, "_");
+  return METRIC_DESCRIPTIONS[key] || null;
+}
+
 function domainMeta(datasetName, taskType) {
   const name = String(datasetName || "").toLowerCase();
   const task = String(taskType || "").toLowerCase();
@@ -1880,7 +1906,10 @@ const Leaderboard = () => {
                     {domainLabel.label}
                   </span>
                   {dataset.evaluation_metric && (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-800/80 text-[11px] text-gray-400 font-medium border border-gray-700/50">
+                    <span
+                      className="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-800/80 text-[11px] text-gray-400 font-medium border border-gray-700/50 cursor-help"
+                      title={metricDescription(dataset.evaluation_metric) || humanizeMetricKey(dataset.evaluation_metric)}
+                    >
                       {humanizeMetricKey(dataset.evaluation_metric)}
                     </span>
                   )}
@@ -1927,12 +1956,16 @@ const Leaderboard = () => {
                     <th className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-left px-2 py-2.5">Model</th>
                     <th
                       className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-right px-5 py-2.5 w-28"
-                      title="Weighted aggregate (0–100) over reported metrics; hover a row for the breakdown."
+                      title={
+                        metricDescription(dataset.evaluation_metric)
+                          ? `${humanizeMetricKey(dataset.evaluation_metric)}: ${metricDescription(dataset.evaluation_metric)}`
+                          : "Weighted aggregate (0–100) over reported metrics; hover a row for the breakdown."
+                      }
                     >
                       Score
                     </th>
                     {extras.map((ek) => (
-                      <th key={ek} className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-right px-2 py-2.5 w-22 max-w-[5.5rem]" title={ek}>
+                      <th key={ek} className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-right px-2 py-2.5 w-22 max-w-[5.5rem]" title={metricDescription(ek) || ek}>
                         <span className="block truncate">{humanizeMetricKey(ek)}</span>
                       </th>
                     ))}


### PR DESCRIPTION
## Summary

- **Closes #47** — adds a `/faq` route with 9 accordion Q&A items covering methodology, trust, benchmark differentiation from MMLU/HELM, metric selection by task type, submission steps, BERTScore vs BLEU rationale, and dataset access. Linked from the header nav bar.
- **Closes #46** — adds a `METRIC_DESCRIPTIONS` map in `Leaderboard.js` with plain-English definitions for 15+ metrics (accuracy, F1 variants, BLEU, BERTScore, ROUGE-L, exact match, MRR, Spearman, pass@1, etc.). Definitions surface as native `title` tooltips on the evaluation metric badge in each dataset card and on the Score/extra-metric column headers.

## Test plan

- [ ] Navigate to `/faq` — accordion items expand and collapse
- [ ] FAQ link appears in the header nav on desktop and mobile
- [ ] On the leaderboard, hover the metric badge (e.g. "Accuracy", "Bleu") on a dataset card — tooltip shows plain-English definition
- [ ] With "Advanced metrics" expanded, hover extra column headers — metric definitions appear
- [ ] Build passes: `npm run build` in `frontend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)