### PR TITLE
Add watch button to leaderboard cards

### DIFF
--- a/frontend/src/landing_page/landing_page_components/DatasetDetails.js
+++ b/frontend/src/landing_page/landing_page_components/DatasetDetails.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import TaskAdvancedMetricsPanel from './TaskAdvancedMetricsPanel';
+import WatchDialog from './WatchDialog';
 
 const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || 'http://localhost:5001';
 
@@ -32,6 +33,7 @@ const DatasetDetails = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [data, setData] = useState(null);
+  const [watchOpen, setWatchOpen] = useState(false);
 
   const decodedName = React.useMemo(() => {
     if (!name) return '';
@@ -93,9 +95,21 @@ const DatasetDetails = () => {
 
   return (
     <div className="flex flex-col items-center justify-start min-h-screen bg-gray-900 pb-24 mx-3">
-      <div className="w-full max-w-5xl mt-6 flex justify-end">
+      <div className="w-full max-w-5xl mt-6 flex justify-end gap-2">
+        {data?.dataset && (
+          <button
+            type="button"
+            onClick={() => setWatchOpen(true)}
+            className="px-3 py-1 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-700/40 flex items-center gap-1"
+          >
+            <span>🔔</span> Watch
+          </button>
+        )}
         <button type="button" onClick={() => navigate('/')} className="px-3 py-1 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-700/40">× Close</button>
       </div>
+      {watchOpen && data?.dataset && (
+        <WatchDialog datasetName={data.dataset.name} onClose={() => setWatchOpen(false)} />
+      )}
       <div className="w-full max-w-5xl bg-gray-900/70 rounded-xl border border-gray-800 p-6 mt-2">
         {loading ? (
           <div className="text-gray-300">Loading…</div>

--- a/frontend/src/landing_page/landing_page_components/Leaderboard.js
+++ b/frontend/src/landing_page/landing_page_components/Leaderboard.js
@@ -3,6 +3,7 @@ import IconButton from "@mui/material/IconButton";
 import Skeleton from "@mui/material/Skeleton";
 import { submittoleaderboardPath, compareModelsPath } from "../../constants/RouteConstants";
 import { useNavigate } from "react-router-dom";
+import WatchDialog from "./WatchDialog";
 
 function humanizeMetricKey(metric) {
   if (!metric || String(metric).trim() === "") return "";
@@ -223,6 +224,7 @@ const Leaderboard = () => {
   const [isDemoMode, setIsDemoMode] = useState(false);
   const [apiFailed, setApiFailed] = useState(false);
   const [refreshNonce, setRefreshNonce] = useState(0);
+  const [watchDatasetName, setWatchDatasetName] = useState(null);
   const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
 
   const liveDatasets = useMemo(() => groupLeaderboardEntries(liveEntries), [liveEntries]);
@@ -1931,6 +1933,14 @@ const Leaderboard = () => {
                 </button>
                 <button
                   type="button"
+                  className="inline-flex items-center gap-1 text-xs px-2.5 py-1.5 rounded-lg border border-gray-700/60 text-gray-500 hover:text-[#defe47] hover:border-[#defe47]/30 transition-colors"
+                  onClick={() => setWatchDatasetName(dataset.name)}
+                  title="Watch this dataset for ranking changes"
+                >
+                  <span>🔔</span> Watch
+                </button>
+                <button
+                  type="button"
                   className="inline-flex items-center gap-1 text-xs px-2.5 py-1.5 rounded-lg border border-gray-700/60 text-gray-500 hover:text-[#28b2fb] hover:border-[#28b2fb]/30 transition-colors"
                   onClick={() => navigate(`/dataset/${encodeURIComponent(dataset.name)}`, {
                     state: {
@@ -2132,6 +2142,9 @@ const Leaderboard = () => {
         </div>
       </div>
 
+      {watchDatasetName && (
+        <WatchDialog datasetName={watchDatasetName} onClose={() => setWatchDatasetName(null)} />
+      )}
     </div>
   );
 };

--- a/frontend/src/landing_page/landing_page_components/WatchDialog.js
+++ b/frontend/src/landing_page/landing_page_components/WatchDialog.js
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || 'http://localhost:5001';
+
+function WatchDialog({ datasetName, onClose }) {
+  const [email, setEmail] = useState('');
+  const [watchType, setWatchType] = useState('beaten');
+  const [status, setStatus] = useState('idle'); // idle | loading | success | error
+  const [message, setMessage] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!email || !email.includes('@')) {
+      setStatus('error'); setMessage('Enter a valid email address.'); return;
+    }
+    setStatus('loading');
+    try {
+      const res = await fetch(
+        `${API_BASE}/public/datasets/${encodeURIComponent(datasetName)}/watch`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, watch_type: watchType }),
+        }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || 'Subscription failed');
+      setStatus('success');
+      setMessage("You're subscribed! You'll get an email when rankings change.");
+    } catch (err) {
+      setStatus('error');
+      setMessage(err.message || 'Something went wrong. Please try again.');
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-[#0d1421] border border-gray-700 rounded-2xl p-6 w-full max-w-sm mx-4 shadow-2xl">
+        <div className="flex justify-between items-start mb-4">
+          <div>
+            <div className="text-white font-bold text-lg">Watch dataset</div>
+            <div className="text-gray-400 text-xs mt-0.5 truncate max-w-[220px]" title={datasetName}>
+              {datasetName}
+            </div>
+          </div>
+          <button onClick={onClose} className="text-gray-500 hover:text-white ml-2 text-xl leading-none">&times;</button>
+        </div>
+
+        {status === 'success' ? (
+          <div className="text-green-400 text-sm py-4 text-center">{message}</div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-gray-300 text-sm mb-1">Your email</label>
+              <input
+                ref={inputRef}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm placeholder-gray-500 focus:outline-none focus:border-[#defe47]"
+              />
+            </div>
+            <div>
+              <div className="text-gray-300 text-sm mb-2">Notify me when</div>
+              <div className="space-y-2">
+                {[
+                  { value: 'beaten', label: 'A new model takes the #1 spot' },
+                  { value: 'top5',   label: 'Any change in the top 5' },
+                ].map(({ value, label }) => (
+                  <label key={value} className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="radio"
+                      name="watch_type"
+                      value={value}
+                      checked={watchType === value}
+                      onChange={() => setWatchType(value)}
+                      className="accent-[#defe47]"
+                    />
+                    <span className="text-gray-200 text-sm">{label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            {status === 'error' && (
+              <div className="text-red-400 text-xs">{message}</div>
+            )}
+            <button
+              type="submit"
+              disabled={status === 'loading'}
+              className="w-full bg-[#defe47] text-black font-bold py-2 rounded-lg text-sm hover:bg-yellow-300 disabled:opacity-50 transition-colors"
+            >
+              {status === 'loading' ? 'Subscribing…' : 'Subscribe'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default WatchDialog;


### PR DESCRIPTION
This PR improves dataset watch discoverability by adding a visible Watch button directly to leaderboard dataset cards.

## Changes

* Extracts WatchDialog into a shared component
* Reuses WatchDialog in DatasetDetails
* Adds a visible Watch button to leaderboard cards
* Opens the existing watch subscription modal with the selected dataset name

## Scope

* Frontend UI enhancement only
* No backend changes
* No notification logic changes
* No watch status or unsubscribe UI changes

## Test plan

* npm run build
* Manually verified the Watch button appears on leaderboard cards
* Manually verified the Watch dialog opens from the leaderboard card
* Manually verified the existing Dataset Details watch flow still works