### PR TITLE
fix: compute Prediction Inspector accuracy from global stats, not current page

### DIFF
--- a/backend/blueprints/submissions.py
+++ b/backend/blueprints/submissions.py
@@ -854,6 +854,21 @@ def submission_examples(submission_id: int):
         det = {}
 
     all_items: List[Dict[str, Any]] = det.get("item_results") or (det.get("detailed_scores") or {}).get("item_results") or []
+
+    # Compute global stats from the full unfiltered item list before pagination.
+    _total_examples = len(all_items)
+    _scored = [it for it in all_items if it.get("correct") is not None]
+    _scored_count = len(_scored)
+    _correct_count = sum(1 for it in _scored if it.get("correct") is True)
+    _wrong_count = _scored_count - _correct_count
+    stats = {
+        "total_examples": _total_examples,
+        "scored_examples": _scored_count,
+        "correct_examples": _correct_count,
+        "wrong_examples": _wrong_count,
+        "accuracy": round(_correct_count / _scored_count, 6) if _scored_count > 0 else None,
+    }
+
     if filter_by == "correct":
         all_items = [it for it in all_items if it.get("correct") is True]
     elif filter_by == "wrong":
@@ -869,6 +884,7 @@ def submission_examples(submission_id: int):
         "offset": offset,
         "limit": limit,
         "examples": page,
+        "stats": stats,
     })
 
 

--- a/backend/tests/test_release_workflows.py
+++ b/backend/tests/test_release_workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 
 try:
@@ -209,3 +210,157 @@ def test_run_llm_submission_validates_dataset_and_provider_failure(monkeypatch):
             time.sleep(0.05)
         assert final_body["status"] == "failed"
         assert "Unknown provider" in final_body["error"]
+
+
+# ---------------------------------------------------------------------------
+# Prediction Inspector — /public/submissions/<id>/examples global stats
+# ---------------------------------------------------------------------------
+
+def _seed_dataset_with_n_items(n: int, name: str = "stats_dataset") -> None:
+    """Seed a classification dataset with n items."""
+    app_module._STORE["datasets"].append({
+        "name": name,
+        "task_type": "text_classification",
+        "evaluation_metric": "accuracy",
+        "reference_data": {
+            "source_texts": [f"text {i}" for i in range(n)],
+            "labels": ["pos" if i % 2 == 0 else "neg" for i in range(n)],
+            "label_names": ["pos", "neg"],
+        },
+    })
+
+
+def _get_examples(client, submission_id: int, owner: str, **params):
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    url = f"/public/submissions/{submission_id}/examples" + (f"?{qs}" if qs else "")
+    return client.get(url, headers=auth_headers(owner))
+
+
+def test_examples_global_stats_mixed_correct_wrong(monkeypatch):
+    """stats reflects the full unfiltered item list even when a page filter is applied."""
+    monkeypatch.setenv("DISABLE_RATE_LIMIT", "1")
+    monkeypatch.setenv("LEADERBOARD_JWT_SECRET", "dev-secret")
+    monkeypatch.setattr(app_module, "get_db_connection", lambda: (None, None))
+    reset_store()
+    _seed_dataset_with_n_items(4, "mixed_dataset")
+
+    with app.test_client() as c:
+        # Submit: first two correct, last two wrong
+        resp = c.post("/public/submit_model", json={
+            "benchmarkDatasetName": "mixed_dataset",
+            "modelName": "mixed-model",
+            "modelResults": ["pos", "neg", "neg", "pos"],  # ids 0,1 correct; 2,3 wrong
+            "sentence_ids": [0, 1, 2, 3],
+        }, headers=auth_headers("stats-owner"))
+        assert resp.status_code == 200
+        sid = resp.get_json()["submission_id"]
+
+        # Filter=all, page 1
+        r = _get_examples(c, sid, "stats-owner", filter="all", offset=0, limit=25)
+        assert r.status_code == 200
+        body = r.get_json()
+
+        stats = body["stats"]
+        assert stats["total_examples"] == 4
+        assert stats["scored_examples"] == 4
+        assert stats["correct_examples"] == 2
+        assert stats["wrong_examples"] == 2
+        assert abs(stats["accuracy"] - 0.5) < 1e-4
+
+        # Filter=correct should still return the same global stats
+        r2 = _get_examples(c, sid, "stats-owner", filter="correct", offset=0, limit=25)
+        assert r2.status_code == 200
+        body2 = r2.get_json()
+        stats2 = body2["stats"]
+        assert stats2["correct_examples"] == 2
+        assert stats2["wrong_examples"] == 2
+        assert abs(stats2["accuracy"] - 0.5) < 1e-4
+        # But the returned examples list should only contain correct items
+        assert all(ex["correct"] is True for ex in body2["examples"])
+
+
+def test_examples_global_stats_all_null_correct(monkeypatch):
+    """When no item has a correct field (e.g. translation task), accuracy must be null."""
+    monkeypatch.setenv("DISABLE_RATE_LIMIT", "1")
+    monkeypatch.setenv("LEADERBOARD_JWT_SECRET", "dev-secret")
+    monkeypatch.setattr(app_module, "get_db_connection", lambda: (None, None))
+    reset_store()
+
+    # Manually inject a submission with item_results where correct=None (translation-style)
+    ds = {
+        "name": "trans_dataset",
+        "task_type": "translation",
+        "evaluation_metric": "bleu",
+        "reference_data": {
+            "source_texts": ["hello", "world"],
+            "reference_translations": ["hola", "mundo"],
+        },
+    }
+    app_module._STORE["datasets"].append(ds)
+
+    # Inject submission + evaluation directly to bypass actual BLEU scoring
+    app_module._STORE["submissions"].append({
+        "id": 999,
+        "benchmark_dataset_id": None,
+        "model_name": "trans-model",
+        "submitted_by": "trans-owner",
+        "submitter_id": "trans-owner",
+        "model_results": ["hola", "mundo"],
+        "is_public": True,
+        "created": "2024-01-01T00:00:00",
+    })
+    app_module._STORE["evaluations"].append({
+        "submission_id": 999,
+        "evaluation_details": json.dumps({
+            "item_results": [
+                {"id": "0", "ground_truth": "hola", "prediction": "hola", "correct": None},
+                {"id": "1", "ground_truth": "mundo", "prediction": "mundo", "correct": None},
+            ]
+        }),
+    })
+
+    with app.test_client() as c:
+        r = _get_examples(c, 999, "trans-owner", filter="all", offset=0, limit=25)
+        assert r.status_code == 200
+        body = r.get_json()
+
+    stats = body["stats"]
+    assert stats["total_examples"] == 2
+    assert stats["scored_examples"] == 0
+    assert stats["correct_examples"] == 0
+    assert stats["accuracy"] is None  # must be null, not NaN or Infinity
+
+
+def test_examples_global_stats_stable_across_pages(monkeypatch):
+    """Global stats are identical regardless of which page (offset) is fetched."""
+    monkeypatch.setenv("DISABLE_RATE_LIMIT", "1")
+    monkeypatch.setenv("LEADERBOARD_JWT_SECRET", "dev-secret")
+    monkeypatch.setattr(app_module, "get_db_connection", lambda: (None, None))
+    reset_store()
+    _seed_dataset_with_n_items(4, "paged_dataset")
+
+    with app.test_client() as c:
+        resp = c.post("/public/submit_model", json={
+            "benchmarkDatasetName": "paged_dataset",
+            "modelName": "paged-model",
+            "modelResults": ["pos", "neg", "pos", "neg"],  # all correct
+            "sentence_ids": [0, 1, 2, 3],
+        }, headers=auth_headers("page-owner"))
+        assert resp.status_code == 200
+        sid = resp.get_json()["submission_id"]
+
+        # Page 1 (items 0-1)
+        r1 = _get_examples(c, sid, "page-owner", filter="all", offset=0, limit=2)
+        assert r1.status_code == 200
+        stats1 = r1.get_json()["stats"]
+
+        # Page 2 (items 2-3)
+        r2 = _get_examples(c, sid, "page-owner", filter="all", offset=2, limit=2)
+        assert r2.status_code == 200
+        stats2 = r2.get_json()["stats"]
+
+        # Global stats must be identical for both pages
+        assert stats1 == stats2
+        assert stats1["total_examples"] == 4
+        assert stats1["scored_examples"] == 4
+        assert abs(stats1["accuracy"] - 1.0) < 1e-4

--- a/frontend/src/landing_page/landing_page_components/SubmissionExamples.js
+++ b/frontend/src/landing_page/landing_page_components/SubmissionExamples.js
@@ -72,9 +72,12 @@ export default function SubmissionExamples() {
 
   const total = data?.total ?? 0;
   const examples = data?.examples ?? [];
-  const correctCount = data?.examples?.filter((e) => e.correct === true).length ?? 0;
   const totalPages = Math.ceil(total / PAGE_SIZE);
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+
+  // Global stats come from the backend (computed before pagination and filtering).
+  const globalStats = data?.stats ?? null;
+  const globalAccuracy = globalStats?.accuracy ?? null; // null means unscored task
 
   const filterTabs = [
     { value: "all", label: "All" },
@@ -144,20 +147,32 @@ export default function SubmissionExamples() {
             {/* Stats row */}
             <div className="flex flex-wrap items-center gap-4 mb-5">
               <div className="rounded-xl border border-gray-800 bg-[#0d1421] px-4 py-3 flex flex-col items-center min-w-[80px]">
-                <span className="text-2xl font-bold text-white tabular-nums">{total}</span>
+                <span className="text-2xl font-bold text-white tabular-nums">
+                  {globalStats ? globalStats.total_examples : total}
+                </span>
                 <span className="text-[11px] text-gray-500 mt-0.5">total</span>
               </div>
-              {total > 0 && data.examples.some((e) => e.correct !== null && e.correct !== undefined) && (
+              {globalStats && globalStats.scored_examples > 0 && (
                 <>
                   <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 flex flex-col items-center min-w-[80px]">
                     <span className="text-2xl font-bold text-emerald-300 tabular-nums">
-                      {filter === "all"
-                        ? `${((data.examples.filter((e) => e.correct === true).length / data.examples.filter((e) => e.correct !== null).length) * 100).toFixed(0)}%`
-                        : correctCount}
+                      {globalAccuracy !== null
+                        ? `${(globalAccuracy * 100).toFixed(1)}%`
+                        : "N/A"}
                     </span>
-                    <span className="text-[11px] text-emerald-400/70 mt-0.5">
-                      {filter === "all" ? "accuracy (this page)" : "correct"}
+                    <span className="text-[11px] text-emerald-400/70 mt-0.5">accuracy</span>
+                  </div>
+                  <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 flex flex-col items-center min-w-[80px]">
+                    <span className="text-2xl font-bold text-emerald-300 tabular-nums">
+                      {globalStats.correct_examples}
                     </span>
+                    <span className="text-[11px] text-emerald-400/70 mt-0.5">correct</span>
+                  </div>
+                  <div className="rounded-xl border border-red-500/20 bg-red-500/5 px-4 py-3 flex flex-col items-center min-w-[80px]">
+                    <span className="text-2xl font-bold text-red-300 tabular-nums">
+                      {globalStats.wrong_examples}
+                    </span>
+                    <span className="text-[11px] text-red-400/70 mt-0.5">wrong</span>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary

- **Bug**: The accuracy stat in the Prediction Inspector was calculated client-side from `data.examples`, which only holds the current paginated page (25 items). This gave a misleading number and could display `NaN%` or `Infinity%` on tasks like translation where `correct` is always `null`.
- **Fix**: The backend now computes global stats across all `item_results` before pagination, and returns them in a new `stats` field. The frontend reads `stats` directly instead of doing any math over the current page.

## Changes

### `backend/blueprints/submissions.py`
- Before filtering/paginating `all_items`, compute:
  - `total_examples`, `scored_examples`, `correct_examples`, `wrong_examples`
  - `accuracy = correct / scored`, or `null` when `scored_examples == 0`
- Added `stats` key to the `/public/submissions/<id>/examples` JSON response.
- Existing keys (`total`, `examples`, `filter`, `offset`, `limit`) are unchanged — no breaking change.

### `frontend/src/landing_page/landing_page_components/SubmissionExamples.js`
- Removed the page-local accuracy calculation (`data.examples.filter(...)`).
- Stats row now reads `data.stats` from the backend:
  - Shows `XX.X%` when `accuracy` is a number.
  - Shows `N/A` when `accuracy` is `null` (unscored task type).
  - Separate cards for **correct** and **wrong** counts with unambiguous labels.
  - Removed the misleading `"accuracy (this page)"` label.

### `backend/tests/test_release_workflows.py`
Three new tests added:
1. `test_examples_global_stats_mixed_correct_wrong` — verifies correct/wrong counts and accuracy; confirms `filter=correct` returns only correct items but leaves global `stats` unchanged.
2. `test_examples_global_stats_all_null_correct` — translation-style task where all `correct` fields are `null`; asserts `accuracy` is `null`, not `NaN` or `Infinity`.
3. `test_examples_global_stats_stable_across_pages` — fetches two different pages and asserts `stats` is identical for both.

All 9 tests in `test_release_workflows.py` pass. Frontend build (`npm run build`) succeeds with no errors.

## Reviewer notes
- No auth behavior changed.
- No other files touched.
- The `stats` key is additive; old clients that ignore unknown fields are unaffected.