### PR TITLE
Add leaderboard export download UI (issue #12)

### DIFF
--- a/backend/blueprints/leaderboard.py
+++ b/backend/blueprints/leaderboard.py
@@ -953,10 +953,16 @@ def export_leaderboard():
         next_cur = payload.get("next_cursor")
         if not next_cur:
             break
-    if export_format == "json":
-        return jsonify(rows)
-    if export_format != "csv":
+    if export_format not in ("json", "csv"):
         return jsonify({"success": False, "error": "format must be csv or json"}), 400
+
+    if export_format == "json":
+        filename = f"leaderboard-{dataset_name or 'all'}.json"
+        return Response(
+            json.dumps(rows, ensure_ascii=False, default=str, indent=2),
+            mimetype="application/json",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
 
     out = StringIO()
     fieldnames = [

--- a/frontend/src/landing_page/landing_page_components/DatasetDetails.js
+++ b/frontend/src/landing_page/landing_page_components/DatasetDetails.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import ReactGA from 'react-ga4';
 import TaskAdvancedMetricsPanel from './TaskAdvancedMetricsPanel';
 
 const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || 'http://localhost:5001';
@@ -20,6 +21,59 @@ function MetricCard({ metricKey, metric }) {
       )}
       {metric.when_to_use && (
         <div className="text-gray-500 text-xs mt-2">When to use: {metric.when_to_use}</div>
+      )}
+    </div>
+  );
+}
+
+function ExportMenu({ datasetName }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClickOutside = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const handleExport = (format) => {
+    setOpen(false);
+    ReactGA.event({ category: 'Leaderboard', action: 'export_leaderboard', label: `${datasetName}:${format}` });
+    const url = new URL(`${API_BASE}/public/export/leaderboard`);
+    url.searchParams.set('dataset', datasetName);
+    url.searchParams.set('format', format);
+    window.location.href = url.toString();
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="px-3 py-1 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-700/40 flex items-center gap-1"
+      >
+        <span>⬇</span> Export
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-36 bg-[#0d1421] border border-gray-700 rounded-lg shadow-2xl z-10 overflow-hidden">
+          <button
+            type="button"
+            onClick={() => handleExport('csv')}
+            className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700/40"
+          >
+            Export as CSV
+          </button>
+          <button
+            type="button"
+            onClick={() => handleExport('json')}
+            className="w-full text-left px-3 py-2 text-sm text-gray-200 hover:bg-gray-700/40"
+          >
+            Export as JSON
+          </button>
+        </div>
       )}
     </div>
   );
@@ -93,7 +147,8 @@ const DatasetDetails = () => {
 
   return (
     <div className="flex flex-col items-center justify-start min-h-screen bg-gray-900 pb-24 mx-3">
-      <div className="w-full max-w-5xl mt-6 flex justify-end">
+      <div className="w-full max-w-5xl mt-6 flex justify-end gap-2">
+        {ds && <ExportMenu datasetName={ds.name} />}
         <button type="button" onClick={() => navigate('/')} className="px-3 py-1 rounded-md border border-gray-700 text-gray-300 hover:bg-gray-700/40">× Close</button>
       </div>
       <div className="w-full max-w-5xl bg-gray-900/70 rounded-xl border border-gray-800 p-6 mt-2">


### PR DESCRIPTION
## Summary
- Closes #12. The backend export endpoint (`GET /public/export/leaderboard?dataset=...&format=csv|json`) already existed but nothing in the UI ever called it — no download button existed anywhere in the app.
- Adds an "⬇ Export" button on the dataset details page with a small menu for **CSV** / **JSON**, next to the existing page actions.
- The JSON export previously returned inline JSON with no `Content-Disposition` header (only CSV forced a download). Fixed the backend so JSON export also downloads as a file, consistent with CSV.
- Tracks the export click via `ReactGA.event()` per this repo's analytics convention.

## Test plan
- [x] `python -m ast` syntax check on `backend/blueprints/leaderboard.py`
- [x] Ran the backend locally and curled both formats:
  - `GET /public/export/leaderboard?dataset=ARC-SMART&format=csv` → 200, `Content-Disposition: attachment; filename=leaderboard-ARC-SMART.csv`, correct rows
  - `GET /public/export/leaderboard?dataset=ARC-SMART&format=json` → 200, `Content-Disposition: attachment; filename=leaderboard-ARC-SMART.json`, valid JSON array
  - `format=xml` → 400 with a clear error message
- [x] Ran the frontend dev server against the local backend; confirmed a clean `webpack compiled successfully` with no errors and the built bundle contains the new `ExportMenu` code
- [x] Confirmed relevant existing export tests (`test_export_leaderboard_*`) behave identically before/after this change — pre-existing failures in this suite are unrelated to this change (verified via `git stash`/before-after comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)