### PR TITLE
feat: Head-to-Head per-example disagreement explorer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ When running locally, override with `REACT_APP_API_ENDPOINT=http://localhost:500
 | GET | `/public/dataset_questions` | Dataset inputs/questions without labels |
 | POST | `/public/submit_model` | Submit model predictions for scoring |
 | GET | `/public/get_leaderboard` | Ranked model results |
+| GET | `/public/compare_models` | Aggregate score comparison across shared datasets |
+| GET | `/public/head_to_head` | Per-example disagreement view for two models on one dataset |
 | GET | `/public/export/leaderboard` | Export leaderboard rows |
 | POST | `/public/import_hf_dataset` | Import a Hugging Face dataset split |
 | POST | `/public/run_hf_model` | Run a Hugging Face model on an imported dataset |

--- a/backend/blueprints/leaderboard.py
+++ b/backend/blueprints/leaderboard.py
@@ -930,6 +930,209 @@ def compare_models():
     return jsonify({'success': True, 'models': model_names_req, 'comparisons': comparisons})
 
 
+def _extract_item_results(det: Any) -> list[dict[str, Any]]:
+    """Pull the per-example item_results list out of an evaluation_details blob.
+
+    Handles both the DB (JSON string) and in-memory (dict) shapes, and both
+    the top-level and nested-under-detailed_scores placements.
+    """
+    if isinstance(det, str):
+        try:
+            det = json.loads(det)
+        except Exception:
+            return []
+    if not isinstance(det, dict):
+        return []
+    items = det.get("item_results")
+    if not items:
+        inner = det.get("detailed_scores")
+        if isinstance(inner, dict):
+            items = inner.get("item_results")
+    return items if isinstance(items, list) else []
+
+
+_H2H_CATEGORIES = ("both_correct", "both_wrong", "a_only", "b_only", "unscored")
+
+
+def _categorize_pair(correct_a: Any, correct_b: Any) -> str:
+    """Bucket an aligned example by which of the two models got it right."""
+    if correct_a is None or correct_b is None:
+        return "unscored"
+    if correct_a and correct_b:
+        return "both_correct"
+    if not correct_a and not correct_b:
+        return "both_wrong"
+    return "a_only" if correct_a else "b_only"
+
+
+@bp.get('/public/head_to_head')
+def head_to_head():
+    """Per-example head-to-head disagreement view for two models on one dataset.
+
+    Query params:
+      models  — comma-separated pair of model names (exactly 2 required)
+      dataset — benchmark dataset name (required)
+      filter  — all | disagreement | a_only | b_only | both_correct | both_wrong | unscored
+      offset  — int (default 0)
+      limit   — int 1–500 (default 100)
+
+    Aligns the two models' best public submissions on the dataset by example id
+    and reports, for every shared example, whether each model was correct and
+    what each predicted — so users can see exactly where the models diverge.
+    """
+    raw = request.args.get('models', '')
+    pair = [m.strip() for m in raw.split(',') if m.strip()]
+    # De-dupe while preserving order so ?models=A,A is rejected cleanly.
+    seen: dict = {}
+    for m in pair:
+        seen.setdefault(m, None)
+    pair = list(seen.keys())
+    if len(pair) != 2:
+        return jsonify({"success": False, "error": "Provide exactly 2 distinct model names via ?models=A,B"}), 400
+
+    dataset_name = (request.args.get('dataset') or '').strip()
+    if not dataset_name:
+        return jsonify({"success": False, "error": "Provide a dataset name via ?dataset="}), 400
+
+    filter_by = (request.args.get('filter') or 'all').lower()
+    valid_filters = ('all', 'disagreement') + _H2H_CATEGORIES
+    if filter_by not in valid_filters:
+        return jsonify({"success": False, "error": f"filter must be one of: {', '.join(valid_filters)}"}), 400
+    try:
+        offset = max(0, int(request.args.get('offset', 0)))
+        limit = min(500, max(1, int(request.args.get('limit', 100))))
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "error": "offset and limit must be integers"}), 400
+
+    model_a, model_b = pair[0], pair[1]
+
+    # best[model] = {"score": float, "items": [...]}; meta captured once.
+    best: dict = {}
+    meta: dict = {"task_type": None, "evaluation_metric": None}
+
+    conn, cursor = get_db_connection()
+    if conn and cursor:
+        try:
+            cursor.execute(
+                "SELECT ms.model_name, er.score, er.evaluation_details, "
+                "bd.task_type, bd.evaluation_metric "
+                "FROM model_submissions ms "
+                "JOIN benchmark_datasets bd ON ms.benchmark_dataset_id = bd.id "
+                "JOIN evaluation_results er ON er.model_submission_id = ms.id "
+                "WHERE ms.model_name IN (%s, %s) "
+                "  AND bd.name = %s "
+                "  AND bd.active = TRUE "
+                "  AND (ms.is_public IS NULL OR ms.is_public = 1) "
+                "ORDER BY er.score DESC",
+                (model_a, model_b, dataset_name),
+            )
+            rows = cursor.fetchall()
+        except Exception as e:
+            logger.exception("head_to_head_db_error", extra={"error": str(e)})
+            rows = []
+        finally:
+            try:
+                cursor.close()
+                conn.close()
+            except Exception:
+                pass
+        for row in rows:
+            mn = row['model_name']
+            score = float(row['score'])
+            if mn in best and score <= best[mn]['score']:
+                continue
+            items = _extract_item_results(row.get('evaluation_details'))
+            if not items:
+                continue
+            best[mn] = {"score": score, "items": items}
+            if meta["task_type"] is None:
+                meta["task_type"] = row.get('task_type')
+                meta["evaluation_metric"] = row.get('evaluation_metric')
+    else:
+        # In-memory fallback.
+        for sub in _STORE.get('submissions', []):
+            mn = sub.get('model_name', '')
+            if mn not in (model_a, model_b):
+                continue
+            if sub.get('benchmark_dataset_name') != dataset_name:
+                continue
+            if sub.get('is_public') is False:
+                continue
+            ev = next((e for e in _STORE.get('evaluations', []) if e.get('submission_id') == sub.get('id')), None)
+            if not ev:
+                continue
+            score = float(ev.get('score', 0))
+            if mn in best and score <= best[mn]['score']:
+                continue
+            items = _extract_item_results(ev.get('evaluation_details'))
+            if not items:
+                continue
+            best[mn] = {"score": score, "items": items}
+
+    for mn in (model_a, model_b):
+        if mn not in best:
+            return jsonify({
+                "success": False,
+                "error": f"No public submission with per-example results found for '{mn}' on '{dataset_name}'",
+            }), 404
+
+    items_a = {it.get('id'): it for it in best[model_a]['items'] if it.get('id') is not None}
+    items_b = {it.get('id'): it for it in best[model_b]['items'] if it.get('id') is not None}
+    shared_ids = [i for i in items_a if i in items_b]
+    # Sort ids numerically when possible for stable, human-friendly ordering.
+    try:
+        shared_ids.sort(key=lambda x: (0, int(x)) if str(x).lstrip('-').isdigit() else (1, str(x)))
+    except Exception:
+        shared_ids.sort(key=lambda x: str(x))
+
+    summary = {k: 0 for k in _H2H_CATEGORIES}
+    aligned: list = []
+    for gid in shared_ids:
+        ia, ib = items_a[gid], items_b[gid]
+        category = _categorize_pair(ia.get('correct'), ib.get('correct'))
+        summary[category] += 1
+        aligned.append({
+            "id": gid,
+            "ground_truth": ia.get('ground_truth'),
+            "prediction_a": ia.get('prediction'),
+            "prediction_b": ib.get('prediction'),
+            "correct_a": ia.get('correct'),
+            "correct_b": ib.get('correct'),
+            "category": category,
+        })
+
+    scored = summary["both_correct"] + summary["both_wrong"] + summary["a_only"] + summary["b_only"]
+    summary["total_aligned"] = len(aligned)
+    summary["a_missing"] = len(items_a) - len(shared_ids)
+    summary["b_missing"] = len(items_b) - len(shared_ids)
+    summary["agreement_rate"] = round((summary["both_correct"] + summary["both_wrong"]) / scored, 6) if scored else None
+
+    if filter_by == 'disagreement':
+        filtered = [it for it in aligned if it['category'] in ('a_only', 'b_only')]
+    elif filter_by in _H2H_CATEGORIES:
+        filtered = [it for it in aligned if it['category'] == filter_by]
+    else:
+        filtered = aligned
+
+    total = len(filtered)
+    page = filtered[offset: offset + limit]
+
+    return jsonify({
+        "success": True,
+        "dataset_name": dataset_name,
+        "task_type": meta["task_type"],
+        "evaluation_metric": meta["evaluation_metric"],
+        "models": {"a": model_a, "b": model_b},
+        "scores": {"a": best[model_a]['score'], "b": best[model_b]['score']},
+        "summary": summary,
+        "filter": filter_by,
+        "offset": offset,
+        "limit": limit,
+        "total": total,
+        "items": page,
+    })
+
+
 @bp.get('/public/export/leaderboard')
 @rate_limit("EXPORT_RATE_LIMIT", "10/minute")
 def export_leaderboard():

--- a/backend/tests/test_head_to_head.py
+++ b/backend/tests/test_head_to_head.py
@@ -1,0 +1,139 @@
+"""Tests for GET /public/head_to_head (per-example disagreement view)."""
+from __future__ import annotations
+
+
+try:
+    import app as app_module
+except ImportError:
+    import backend.app as app_module  # type: ignore
+
+app = app_module.app
+DATASET = "SST-2 Sentiment (Sample)"
+
+# Ground-truth labels for the seeded SST-2 sample (see test_compare_models).
+GT = ["0", "1", "0", "1", "0", "0", "1", "0", "0", "1",
+      "1", "1", "0", "0", "1", "1", "0", "1", "1", "1"]
+
+
+def reset_store() -> None:
+    app_module._STORE["submissions"].clear()
+    app_module._STORE["evaluations"].clear()
+    app_module._STORE["datasets"].clear()
+    app_module._STORE.setdefault("submission_counts", {}).clear()
+    app_module.LEADERBOARD_DATA.clear()
+    app_module._AUTO_SEED_DONE = False
+
+
+def seed(c):
+    """Alpha is perfect; Beta predicts all-negative (0)."""
+    c.get("/health")  # triggers auto-seed
+    c.post("/public/submit_model", json={
+        "benchmarkDatasetName": DATASET, "modelName": "Alpha",
+        "modelResults": GT, "submitterId": "tester",
+    })
+    c.post("/public/submit_model", json={
+        "benchmarkDatasetName": DATASET, "modelName": "Beta",
+        "modelResults": ["0"] * 20, "submitterId": "tester",
+    })
+
+
+def _client(monkeypatch):
+    monkeypatch.setenv("DISABLE_RATE_LIMIT", "1")
+    monkeypatch.setenv("LEADERBOARD_AUTO_SEED_IN_TESTS", "1")
+    monkeypatch.setenv("REQUIRE_API_KEY", "false")
+    monkeypatch.setenv("LEADERBOARD_API_KEYS", "")
+    monkeypatch.setattr(app_module, "get_db_connection", lambda: (None, None))
+    reset_store()
+    return app.test_client()
+
+
+def test_requires_exactly_two_models(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    assert c.get(f"/public/head_to_head?models=Alpha&dataset={DATASET}").status_code == 400
+    assert c.get(f"/public/head_to_head?models=Alpha,Beta,Gamma&dataset={DATASET}").status_code == 400
+    # Duplicate collapses to one distinct model -> 400.
+    assert c.get(f"/public/head_to_head?models=Alpha,Alpha&dataset={DATASET}").status_code == 400
+
+
+def test_requires_dataset(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    assert c.get("/public/head_to_head?models=Alpha,Beta").status_code == 400
+
+
+def test_unknown_model_returns_404(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    r = c.get(f"/public/head_to_head?models=Alpha,Ghost&dataset={DATASET}")
+    assert r.status_code == 404
+    assert r.get_json()["success"] is False
+
+
+def test_bad_filter_rejected(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    assert c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}&filter=nope").status_code == 400
+
+
+def test_summary_and_categories(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    r = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}")
+    assert r.status_code == 200
+    body = r.get_json()
+    s = body["summary"]
+
+    # 20 aligned examples, all scored (binary classification task).
+    assert s["total_aligned"] == 20
+    assert s["unscored"] == 0
+    assert s["a_missing"] == 0 and s["b_missing"] == 0
+    # The four correctness buckets partition every scored example.
+    assert s["both_correct"] + s["both_wrong"] + s["a_only"] + s["b_only"] == 20
+    scored = s["both_correct"] + s["both_wrong"] + s["a_only"] + s["b_only"]
+    assert abs(s["agreement_rate"] - ((s["both_correct"] + s["both_wrong"]) / scored)) < 1e-9
+    # Alpha's predictions are stronger than Beta's all-negative baseline.
+    assert body["scores"]["a"] > body["scores"]["b"]
+    # Every returned item's category is consistent with its correctness flags.
+    for it in body["items"]:
+        expected = (
+            "both_correct" if it["correct_a"] and it["correct_b"]
+            else "both_wrong" if not it["correct_a"] and not it["correct_b"]
+            else "a_only" if it["correct_a"]
+            else "b_only"
+        )
+        assert it["category"] == expected
+
+
+def test_disagreement_filter_matches_wins(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    full = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}").get_json()["summary"]
+    dis = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}&filter=disagreement").get_json()
+    # Disagreements = examples exactly one model got right.
+    assert dis["total"] == full["a_only"] + full["b_only"]
+    assert all(it["category"] in ("a_only", "b_only") for it in dis["items"])
+    a_only = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}&filter=a_only").get_json()
+    assert a_only["total"] == full["a_only"]
+    assert all(it["correct_a"] is True and it["correct_b"] is False for it in a_only["items"])
+
+
+def test_swap_order_flips_sides(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    forward = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}").get_json()
+    reverse = c.get(f"/public/head_to_head?models=Beta,Alpha&dataset={DATASET}").get_json()
+    assert forward["summary"]["a_only"] == reverse["summary"]["b_only"]
+    assert forward["summary"]["b_only"] == reverse["summary"]["a_only"]
+
+
+def test_pagination(monkeypatch):
+    c = _client(monkeypatch)
+    seed(c)
+    page = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}&limit=5&offset=0").get_json()
+    assert len(page["items"]) == 5
+    assert page["total"] == 20
+    page2 = c.get(f"/public/head_to_head?models=Alpha,Beta&dataset={DATASET}&limit=5&offset=5").get_json()
+    ids1 = {it["id"] for it in page["items"]}
+    ids2 = {it["id"] for it in page2["items"]}
+    assert ids1.isdisjoint(ids2)

--- a/frontend/src/constants/RouteConstants.js
+++ b/frontend/src/constants/RouteConstants.js
@@ -12,6 +12,7 @@ export const csvBenchmarksPath = "/benchmarks";
 export const addDatasetPath = "/datasets/new";
 export const createLeaderboardPath = "/create-leaderboard";
 export const compareModelsPath = "/compare";
+export const headToHeadPath = "/head-to-head";
 export const modelCardPath = "/model/:name";
 export const submissionExamplesPath = "/submissions/:id/examples";
 export const faqPath = "/faq";

--- a/frontend/src/landing_page/LandingPage.js
+++ b/frontend/src/landing_page/LandingPage.js
@@ -34,11 +34,13 @@ import {
   createLeaderboardPath,
   faqPath,
   compareModelsPath,
+  headToHeadPath,
   modelCardPath,
   submissionExamplesPath,
 } from "../constants/RouteConstants";
 import MySubmissions from "./landing_page_components/MySubmissions";
 import ModelComparison from "./landing_page_components/ModelComparison";
+import HeadToHead from "./landing_page_components/HeadToHead";
 import ModelCard from "./landing_page_components/ModelCard";
 import SubmissionExamples from "./landing_page_components/SubmissionExamples";
 import HeaderBar from "./landing_page_components/HeaderBar";
@@ -142,6 +144,7 @@ function LandingPage() {
           ,
           <Route path="/dataset/:name" element={<DatasetDetails />} />,
           <Route path={compareModelsPath} element={<ModelComparison />} />,
+          <Route path={headToHeadPath} element={<HeadToHead />} />,
           <Route path={modelCardPath} element={<ModelCard />} />,
           <Route
             path={submissionExamplesPath}

--- a/frontend/src/landing_page/landing_page_components/HeadToHead.js
+++ b/frontend/src/landing_page/landing_page_components/HeadToHead.js
@@ -1,0 +1,379 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { compareModelsPath } from "../../constants/RouteConstants";
+
+const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
+const PAGE_SIZE = 25;
+
+// A = lime (M1), B = blue (M2) — mirrors the ModelComparison color scheme.
+const A_TEXT = "text-[#defe47]";
+const B_TEXT = "text-[#28b2fb]";
+
+function pctLabel(rate) {
+  if (rate == null) return "—";
+  return `${(rate * 100).toFixed(0)}%`;
+}
+
+function cellValue(v) {
+  if (v == null) return null;
+  if (Array.isArray(v)) return v.join(", ");
+  return String(v);
+}
+
+function StatTile({ value, label, accent }) {
+  return (
+    <div className={`rounded-xl border ${accent.border} ${accent.bg} px-4 py-3 flex flex-col items-center min-w-[92px]`}>
+      <span className={`text-2xl font-bold tabular-nums ${accent.text}`}>{value}</span>
+      <span className="text-[11px] text-gray-400 mt-0.5 text-center leading-tight">{label}</span>
+    </div>
+  );
+}
+
+function VerdictBadge({ category }) {
+  const map = {
+    a_only: { text: "M1 only", cls: "bg-[#defe47]/15 text-[#defe47] border-[#defe47]/40" },
+    b_only: { text: "M2 only", cls: "bg-[#28b2fb]/15 text-[#28b2fb] border-[#28b2fb]/40" },
+    both_correct: { text: "Both right", cls: "bg-emerald-500/15 text-emerald-300 border-emerald-400/30" },
+    both_wrong: { text: "Both wrong", cls: "bg-red-500/15 text-red-300 border-red-400/30" },
+    unscored: { text: "N/A", cls: "bg-gray-700/60 text-gray-400 border-gray-600/50" },
+  };
+  const m = map[category] || map.unscored;
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold border ${m.cls}`}>
+      {m.text}
+    </span>
+  );
+}
+
+export default function HeadToHead() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const modelsParam = searchParams.get("models") || "";
+  const [modelA, modelB] = modelsParam.split(",").map((s) => s.trim());
+  const dataset = searchParams.get("dataset") || "";
+
+  const [filter, setFilter] = useState("all");
+  const [offset, setOffset] = useState(0);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [sharedDatasets, setSharedDatasets] = useState([]);
+
+  const ready = Boolean(modelA && modelB && dataset);
+
+  // Populate the dataset switcher with datasets both models share.
+  useEffect(() => {
+    if (!modelA || !modelB) return;
+    const url = new URL(`${API_BASE}/public/compare_models`);
+    url.searchParams.set("models", `${modelA},${modelB}`);
+    fetch(url.toString())
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.success) setSharedDatasets((d.comparisons || []).map((c) => c.dataset_name));
+      })
+      .catch(() => {});
+  }, [modelA, modelB]);
+
+  const fetchData = useCallback(async (f, o) => {
+    if (!ready) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const url = new URL(`${API_BASE}/public/head_to_head`);
+      url.searchParams.set("models", `${modelA},${modelB}`);
+      url.searchParams.set("dataset", dataset);
+      url.searchParams.set("filter", f);
+      url.searchParams.set("offset", o);
+      url.searchParams.set("limit", PAGE_SIZE);
+      const res = await fetch(url.toString());
+      const json = await res.json();
+      if (!res.ok || json.success === false) {
+        setError(json.error || "Failed to load comparison");
+        setData(null);
+        return;
+      }
+      setData(json);
+    } catch (e) {
+      setError(e.message || "Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, [ready, modelA, modelB, dataset]);
+
+  useEffect(() => {
+    setOffset(0);
+    fetchData(filter, 0);
+  }, [filter, fetchData]);
+
+  const handlePage = (newOffset) => {
+    setOffset(newOffset);
+    fetchData(filter, newOffset);
+  };
+
+  const swapModels = () => {
+    setSearchParams({ models: `${modelB},${modelA}`, dataset });
+  };
+
+  const changeDataset = (ds) => {
+    setSearchParams({ models: `${modelA},${modelB}`, dataset: ds });
+  };
+
+  const summary = data?.summary;
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+  const isScored = summary && (summary.both_correct + summary.both_wrong + summary.a_only + summary.b_only) > 0;
+
+  const filterTabs = useMemo(() => {
+    const tabs = [{ value: "all", label: "All examples" }];
+    if (isScored) {
+      tabs.push(
+        { value: "disagreement", label: "Disagreements" },
+        { value: "a_only", label: "M1 wins" },
+        { value: "b_only", label: "M2 wins" },
+        { value: "both_correct", label: "Both right" },
+        { value: "both_wrong", label: "Both wrong" },
+      );
+    }
+    return tabs;
+  }, [isScored]);
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-[#111827] pb-24 px-4 text-gray-100">
+      <div className="w-full max-w-5xl mt-10">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6 flex-wrap">
+          <button
+            type="button"
+            onClick={() => navigate(compareModelsPath + (modelsParam ? `?models=${encodeURIComponent(modelsParam)}` : ""))}
+            className="text-gray-500 hover:text-gray-300 transition-colors text-sm flex items-center gap-1"
+          >
+            ← Comparison
+          </button>
+          <div className="h-4 w-px bg-gray-700" />
+          <h1 className="text-xl font-bold text-white">Head-to-Head Inspector</h1>
+        </div>
+
+        {!ready && (
+          <div className="rounded-xl border border-gray-800 bg-[#0d1421] px-6 py-12 text-center">
+            <p className="text-white font-semibold mb-2">Pick two models and a shared dataset</p>
+            <p className="text-gray-400 text-sm mb-5">
+              This view aligns two models' predictions example-by-example so you can see exactly where they disagree.
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate(compareModelsPath)}
+              className="px-4 py-2 rounded-lg bg-[#defe47] text-black text-sm font-semibold hover:bg-[#e8ff70] transition-colors"
+            >
+              Go to Model Comparison
+            </button>
+          </div>
+        )}
+
+        {ready && (
+          <>
+            {/* Matchup bar */}
+            <div className="bg-[#0d1421] border border-gray-800 rounded-2xl px-5 py-4 mb-5 flex flex-wrap items-center gap-x-4 gap-y-3">
+              <div className="flex items-center gap-2 min-w-0">
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded bg-[#defe47]/20 ${A_TEXT}`}>M1</span>
+                <span className="text-sm text-white truncate max-w-[13rem]" title={modelA}>{modelA}</span>
+                {data && <span className={`text-xs font-semibold ${A_TEXT} tabular-nums`}>{Number(data.scores.a).toFixed(4)}</span>}
+              </div>
+              <button
+                type="button"
+                onClick={swapModels}
+                title="Swap sides"
+                className="text-gray-500 hover:text-gray-200 text-sm px-1.5 transition-colors"
+              >
+                ⇄
+              </button>
+              <div className="flex items-center gap-2 min-w-0">
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded bg-[#28b2fb]/20 ${B_TEXT}`}>M2</span>
+                <span className="text-sm text-white truncate max-w-[13rem]" title={modelB}>{modelB}</span>
+                {data && <span className={`text-xs font-semibold ${B_TEXT} tabular-nums`}>{Number(data.scores.b).toFixed(4)}</span>}
+              </div>
+              <div className="ml-auto flex items-center gap-2">
+                <span className="text-[11px] uppercase tracking-wider text-gray-600">Dataset</span>
+                {sharedDatasets.length > 1 ? (
+                  <select
+                    value={dataset}
+                    onChange={(e) => changeDataset(e.target.value)}
+                    className="bg-gray-900/80 border border-gray-700 rounded-lg text-sm text-gray-200 px-2.5 py-1.5 focus:outline-none focus:border-gray-500 max-w-[16rem]"
+                  >
+                    {sharedDatasets.map((ds) => (
+                      <option key={ds} value={ds}>{ds}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className="text-sm text-gray-200 truncate max-w-[16rem]" title={dataset}>{dataset}</span>
+                )}
+              </div>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-red-200 text-sm mb-5">
+                {error}
+              </div>
+            )}
+
+            {/* Loading */}
+            {loading && !error && (
+              <div className="flex items-center justify-center py-24">
+                <div className="w-8 h-8 rounded-full border-2 border-gray-700 border-t-[#defe47] animate-spin" />
+              </div>
+            )}
+
+            {!loading && !error && data && summary && (
+              <>
+                {/* Summary tiles */}
+                <div className="flex flex-wrap items-stretch gap-3 mb-6">
+                  <StatTile
+                    value={pctLabel(summary.agreement_rate)}
+                    label="agreement"
+                    accent={{ border: "border-gray-700", bg: "bg-gray-800/40", text: "text-white" }}
+                  />
+                  <StatTile
+                    value={summary.a_only}
+                    label={<>only <span className={A_TEXT}>M1</span> right</>}
+                    accent={{ border: "border-[#defe47]/30", bg: "bg-[#defe47]/10", text: A_TEXT }}
+                  />
+                  <StatTile
+                    value={summary.b_only}
+                    label={<>only <span className={B_TEXT}>M2</span> right</>}
+                    accent={{ border: "border-[#28b2fb]/30", bg: "bg-[#28b2fb]/10", text: B_TEXT }}
+                  />
+                  <StatTile
+                    value={summary.both_correct}
+                    label="both right"
+                    accent={{ border: "border-emerald-500/30", bg: "bg-emerald-500/10", text: "text-emerald-300" }}
+                  />
+                  <StatTile
+                    value={summary.both_wrong}
+                    label="both wrong"
+                    accent={{ border: "border-red-500/30", bg: "bg-red-500/10", text: "text-red-300" }}
+                  />
+                  <StatTile
+                    value={summary.total_aligned}
+                    label="aligned examples"
+                    accent={{ border: "border-gray-700", bg: "bg-gray-800/40", text: "text-gray-300" }}
+                  />
+                </div>
+
+                {!isScored && (
+                  <div className="rounded-lg border border-gray-700/60 bg-gray-800/30 px-4 py-2.5 text-xs text-gray-400 mb-4">
+                    This is a generative task (e.g. translation), so there's no per-example right/wrong label — predictions are shown side by side for inspection.
+                  </div>
+                )}
+
+                {/* Filter tabs */}
+                <div className="flex gap-2 mb-4 flex-wrap">
+                  {filterTabs.map((t) => (
+                    <button
+                      key={t.value}
+                      type="button"
+                      onClick={() => setFilter(t.value)}
+                      className={[
+                        "px-3.5 py-1.5 rounded-full text-xs font-semibold border transition-colors",
+                        filter === t.value
+                          ? "bg-[#defe47]/10 border-[#defe47]/50 text-[#defe47]"
+                          : "bg-transparent border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
+                      ].join(" ")}
+                    >
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Table */}
+                {items.length === 0 ? (
+                  <div className="rounded-xl border border-gray-800 bg-[#0d1421] px-6 py-12 text-center text-gray-500 text-sm">
+                    No examples match this filter.
+                  </div>
+                ) : (
+                  <div className="rounded-xl border border-gray-800 bg-[#0d1421] overflow-hidden">
+                    <div className="overflow-x-auto">
+                      <table className="w-full border-collapse text-sm">
+                        <thead>
+                          <tr className="border-b border-gray-800/60">
+                            <th className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-left px-4 py-3 w-12">#</th>
+                            <th className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-left px-3 py-3 w-40">Ground Truth</th>
+                            <th className={`text-[10px] font-semibold uppercase tracking-widest text-left px-3 py-3 ${A_TEXT}`}>M1 · {modelA}</th>
+                            <th className={`text-[10px] font-semibold uppercase tracking-widest text-left px-3 py-3 ${B_TEXT}`}>M2 · {modelB}</th>
+                            <th className="text-[10px] font-semibold uppercase tracking-widest text-gray-600 text-center px-4 py-3 w-28">Verdict</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-800/30">
+                          {items.map((it, i) => {
+                            const gt = cellValue(it.ground_truth);
+                            const pa = cellValue(it.prediction_a);
+                            const pb = cellValue(it.prediction_b);
+                            const aCls = it.correct_a === true ? "text-emerald-300" : it.correct_a === false ? "text-red-300" : "text-gray-300";
+                            const bCls = it.correct_b === true ? "text-emerald-300" : it.correct_b === false ? "text-red-300" : "text-gray-300";
+                            const rowHover = it.category === "a_only" ? "hover:bg-[#defe47]/[0.04]" : it.category === "b_only" ? "hover:bg-[#28b2fb]/[0.04]" : "hover:bg-white/[0.02]";
+                            return (
+                              <tr key={it.id ?? i} className={`transition-colors ${rowHover}`}>
+                                <td className="px-4 py-3 text-[11px] text-gray-600 tabular-nums font-mono">{offset + i + 1}</td>
+                                <td className="px-3 py-3 text-gray-300 max-w-[10rem]">
+                                  <div className="line-clamp-3 text-xs leading-relaxed font-mono" title={gt ?? ""}>
+                                    {gt != null ? gt : <span className="text-gray-600 italic">—</span>}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-3 max-w-[12rem]">
+                                  <div className={`line-clamp-3 text-xs leading-relaxed font-mono ${aCls}`} title={pa ?? ""}>
+                                    {pa != null ? pa : <span className="text-gray-600 italic">—</span>}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-3 max-w-[12rem]">
+                                  <div className={`line-clamp-3 text-xs leading-relaxed font-mono ${bCls}`} title={pb ?? ""}>
+                                    {pb != null ? pb : <span className="text-gray-600 italic">—</span>}
+                                  </div>
+                                </td>
+                                <td className="px-4 py-3 text-center">
+                                  <VerdictBadge category={it.category} />
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Pagination */}
+                    {totalPages > 1 && (
+                      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-800/40">
+                        <span className="text-xs text-gray-500">
+                          Page {currentPage} of {totalPages} · {total} examples
+                        </span>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            disabled={offset === 0}
+                            onClick={() => handlePage(Math.max(0, offset - PAGE_SIZE))}
+                            className="px-3 py-1.5 rounded-lg border border-gray-700 text-xs text-gray-400 hover:text-white hover:border-gray-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                          >
+                            ← Prev
+                          </button>
+                          <button
+                            type="button"
+                            disabled={offset + PAGE_SIZE >= total}
+                            onClick={() => handlePage(offset + PAGE_SIZE)}
+                            className="px-3 py-1.5 rounded-lg border border-gray-700 text-xs text-gray-400 hover:text-white hover:border-gray-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                          >
+                            Next →
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/landing_page/landing_page_components/ModelComparison.js
+++ b/frontend/src/landing_page/landing_page_components/ModelComparison.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { headToHeadPath } from '../../constants/RouteConstants';
 
 const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || 'http://localhost:5001';
 
@@ -85,7 +86,7 @@ function ModelAutocomplete({ value, index, availableModels, color, onChange, onR
   );
 }
 
-function ComparisonTable({ models, comparisons }) {
+function ComparisonTable({ models, comparisons, onInspect }) {
   const winCounts = Object.fromEntries(models.map(m => [m, 0]));
   const missing = Object.fromEntries(models.map(m => [m, 0]));
 
@@ -130,6 +131,9 @@ function ComparisonTable({ models, comparisons }) {
               ))}
               {exactlyTwo && (
                 <th className="text-right px-4 py-3 text-[11px] font-semibold uppercase tracking-wider text-gray-500 w-20">Δ</th>
+              )}
+              {exactlyTwo && (
+                <th className="px-3 py-3 w-10" aria-label="Inspect" />
               )}
             </tr>
           </thead>
@@ -182,6 +186,18 @@ function ComparisonTable({ models, comparisons }) {
                       ) : (
                         <span className="text-gray-600">tie</span>
                       )}
+                    </td>
+                  )}
+                  {exactlyTwo && (
+                    <td className="px-3 py-3 text-right">
+                      <button
+                        type="button"
+                        title="Inspect per-example disagreements"
+                        onClick={() => onInspect(row.dataset_name)}
+                        className="text-gray-600 hover:text-[#defe47] transition-colors text-base leading-none"
+                      >
+                        ⌕
+                      </button>
                     </td>
                   )}
                 </tr>
@@ -352,7 +368,17 @@ const ModelComparison = () => {
 
         {/* Results */}
         {!loading && comparisons.length > 0 && (
-          <ComparisonTable models={resultModels} comparisons={comparisons} />
+          <ComparisonTable
+            models={resultModels}
+            comparisons={comparisons}
+            onInspect={(datasetName) => {
+              const params = new URLSearchParams({
+                models: resultModels.join(','),
+                dataset: datasetName,
+              });
+              navigate(`${headToHeadPath}?${params.toString()}`);
+            }}
+          />
         )}
 
         {/* Helper: delta legend when exactly 2 models */}
@@ -360,6 +386,7 @@ const ModelComparison = () => {
           <div className="mt-3 flex items-center gap-4 text-xs text-gray-600 px-1">
             <span><span className="text-[#defe47]">+x.xxxx</span> = M1 wins by that margin</span>
             <span><span className="text-[#28b2fb]">−x.xxxx</span> = M2 wins by that margin</span>
+            <span><span className="text-[#defe47]">⌕</span> = inspect per-example disagreements</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Delivers **Phase 4 of the Prediction Inspector** roadmap: a **Head-to-Head Inspector** that lets anyone pick two models and see, example-by-example, *exactly where they disagree* on a shared benchmark — not just which one scored higher.

Aggregate leaderboard scores tell you *that* Model A beats Model B; this tells you *how*: on which specific examples A is right and B is wrong (and vice-versa), with predictions side by side.

## What's new

**Backend — `GET /public/head_to_head`**
- Params: `models=A,B` (exactly 2 distinct), `dataset=<name>`, `filter`, `offset`, `limit`.
- Aligns each model's **best public submission** on the dataset by example id, then buckets every shared example into `both_correct` / `both_wrong` / `a_only` / `b_only` / `unscored` (generative tasks like translation have no right/wrong label).
- Returns an **agreement rate**, per-bucket summary counts, and a filterable/paginated item list with ground truth + both predictions + correctness flags.
- Works across SQLite/MySQL and the in-memory fallback; only surfaces public submissions, consistent with `compare_models`.

**Frontend — `/head-to-head`**
- Summary stat tiles (agreement, only-M1-right, only-M2-right, both right, both wrong, aligned count).
- Filter tabs: All / Disagreements / M1 wins / M2 wins / Both right / Both wrong.
- Side-by-side prediction table with correctness coloring and verdict badges.
- Shared-dataset switcher (populated via `compare_models`) and a one-click side swap.
- **Entry point:** an inspect (⌕) action on each row of the 2-model Model Comparison table.

## Testing
- `backend/tests/test_head_to_head.py` — 8 cases: input validation, 404 for unknown model, bad-filter rejection, category/summary invariants, disagreement filter, side-swap symmetry, pagination. All green.
- Existing `test_compare_models.py` still passes.
- Frontend `react-scripts build` compiles cleanly; ESLint clean on changed files.

## Notes
- Only public submissions are exposed, matching the existing transparency model of `/public/compare_models` (which already returns public detailed scores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)