### PR TITLE
feat: shareable links + CSV export for Prediction Inspector examples

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: verify
+description: Build, launch, and drive the Leaderboard app end-to-end to verify a change at its runtime surface (backend API + React GUI).
+---
+
+# Verify — Anote Model Leaderboard
+
+## Backend (Flask API)
+
+Use the repo-root venv (`.venv/bin/python`); `backend/.venv` also works.
+
+```bash
+cd backend && ALLOWED_ORIGINS=http://localhost:<FRONTEND_PORT> \
+  LEADERBOARD_JWT_SECRET=<any-long-secret> DISABLE_RATE_LIMIT=1 \
+  REQUIRE_API_KEY=false LEADERBOARD_API_KEYS= \
+  SQLITE_DB_PATH=<scratch>/verify.db PORT=5057 FLASK_ENV=development \
+  ../.venv/bin/python app.py
+```
+
+- Poll `GET /health` until up.
+- Mint a user JWT: `python -c "import jwt; print(jwt.encode({'sub':'verify-user'}, '<secret>', algorithm='HS256'))"`.
+- Seed data over HTTP: `POST /public/add_dataset` (classification: `reference_data` with `source_texts`, `labels`, `label_names`), then `POST /public/submit_model` with `benchmarkDatasetName`, `modelName`, `modelResults`, `sentence_ids`. Both accept `Authorization: Bearer <jwt>`.
+
+## Gotchas
+
+- The local `backend/.env` sets API-key enforcement — always override `LEADERBOARD_API_KEYS=`/`REQUIRE_API_KEY=false` explicitly (dotenv does not override existing env vars). This also makes one pre-existing test fail unless `LEADERBOARD_API_KEYS= REQUIRE_API_KEY= python -m pytest ...`.
+- Ports 3000/3001 are often occupied by other apps on this machine — pick a free port and pass it via `ALLOWED_ORIGINS` (CORS blocks other origins even in development).
+- The SPA stores the login JWT in **sessionStorage** key `lb_jwt` (not localStorage).
+- CSS `uppercase` transforms mean `innerText` checks must be case-insensitive.
+
+## Frontend (React GUI, headless Chrome)
+
+CRA bakes the API base at build time:
+
+```bash
+cd frontend && REACT_APP_API_BASE=http://127.0.0.1:5057 npm run build
+```
+
+No Playwright installed; use `puppeteer-core` (scratchpad `npm i puppeteer-core serve-handler`) with the installed Chrome at
+`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`.
+Serve `frontend/build` with serve-handler and a `**` → `/index.html` rewrite (SPA routing), then drive pages, click buttons, screenshot.
+`puppeteer-core` is ESM — use `await import("puppeteer-core")` from CJS scripts.
+Enable downloads via CDP `Browser.setDownloadBehavior` to verify CSV export buttons.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,9 @@ GET  /public/my_submissions
 GET  /public/submission_quota
 GET  /public/submissions/<id>
 DELETE /public/submissions/<id>
+GET  /public/submissions/<id>/examples
+GET  /public/submissions/<id>/examples/export
+POST /public/submissions/<id>/share
 POST /public/import_hf_dataset
 POST /public/run_hf_model
 GET  /public/benchmark_csvs

--- a/backend/app.py
+++ b/backend/app.py
@@ -201,6 +201,42 @@ def openapi_spec():
                     "parameters": [{"name": "submission_id", "in": "path", "required": True, "schema": {"type": "integer"}}],
                 }
             },
+            "/public/submissions/{submission_id}/examples": {
+                "get": {
+                    "summary": "Per-example prediction results (owner or share token)",
+                    "parameters": [
+                        {"name": "submission_id", "in": "path", "required": True, "schema": {"type": "integer"}},
+                        {"name": "filter", "in": "query", "schema": {"type": "string", "enum": ["all", "correct", "wrong"], "default": "all"}},
+                        {"name": "offset", "in": "query", "schema": {"type": "integer", "default": 0}},
+                        {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+                        {"name": "share", "in": "query", "schema": {"type": "string"}, "description": "Read-only share token minted via POST /public/submissions/{submission_id}/share"},
+                    ],
+                }
+            },
+            "/public/submissions/{submission_id}/examples/export": {
+                "get": {
+                    "summary": "Download per-example results as CSV (owner or share token)",
+                    "parameters": [
+                        {"name": "submission_id", "in": "path", "required": True, "schema": {"type": "integer"}},
+                        {"name": "filter", "in": "query", "schema": {"type": "string", "enum": ["all", "correct", "wrong"], "default": "all"}},
+                        {"name": "share", "in": "query", "schema": {"type": "string"}},
+                    ],
+                }
+            },
+            "/public/submissions/{submission_id}/share": {
+                "post": {
+                    "summary": "Mint a read-only share token for a submission's examples (owner only)",
+                    "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+                    "parameters": [{"name": "submission_id", "in": "path", "required": True, "schema": {"type": "integer"}}],
+                    "requestBody": {
+                        "required": False,
+                        "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "properties": {"expires_in_days": {"type": "integer", "minimum": 1, "maximum": 90, "default": 30}},
+                        }}},
+                    },
+                }
+            },
             "/public/get_leaderboard": {
                 "get": {
                     "summary": "Get leaderboard rows",

--- a/backend/blueprints/submissions.py
+++ b/backend/blueprints/submissions.py
@@ -784,27 +784,67 @@ def submission_detail(submission_id: int):
     })
 
 
-@bp.get("/public/submissions/<int:submission_id>/examples")
-def submission_examples(submission_id: int):
-    """Per-example prediction results for a submission.
+_SHARE_TOKEN_SCOPE = "submission-examples"
+_SHARE_DEFAULT_DAYS = 30
+_SHARE_MAX_DAYS = 90
 
-    Query params:
-      filter  = all | correct | wrong   (default: all)
-      offset  = int (default 0)
-      limit   = int 1–500 (default 100)
-    """
-    sub, err = _require_submission_owner(request, submission_id)
-    if err:
-        return err
 
-    filter_by = request.args.get("filter", "all").lower()
-    if filter_by not in ("all", "correct", "wrong"):
-        return jsonify({"success": False, "error": "filter must be all, correct, or wrong"}), 400
+def _mint_share_token(submission_id: int, expires_in_days: int) -> Optional[str]:
+    """HS256 token granting read access to one submission's examples. None if no secret."""
+    secret = os.getenv("LEADERBOARD_JWT_SECRET", "").strip()
+    if not secret:
+        return None
+    import jwt as pyjwt
+
+    now = datetime.now(timezone.utc)
+    return pyjwt.encode(
+        {
+            "share_submission_id": submission_id,
+            "scope": _SHARE_TOKEN_SCOPE,
+            "iat": now,
+            "exp": now + timedelta(days=expires_in_days),
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+
+def _share_token_grants(request, submission_id: int) -> bool:
+    """True when ``?share=`` carries a valid, unexpired token for this submission."""
+    token = (request.args.get("share") or "").strip()
+    if not token:
+        return False
+    secret = os.getenv("LEADERBOARD_JWT_SECRET", "").strip()
+    if not secret:
+        return False
     try:
-        offset = max(0, int(request.args.get("offset", 0)))
-        limit = min(500, max(1, int(request.args.get("limit", 100))))
-    except (ValueError, TypeError):
-        return jsonify({"success": False, "error": "offset and limit must be integers"}), 400
+        import jwt as pyjwt
+
+        claims = pyjwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            options={"require": ["exp"], "verify_exp": True},
+        )
+    except Exception:
+        return False
+    return (
+        claims.get("scope") == _SHARE_TOKEN_SCOPE
+        and claims.get("share_submission_id") == submission_id
+    )
+
+
+def _load_submission_examples(request, submission_id: int):
+    """Authorize (owner or share token) and load item_results.
+
+    Returns (items, error_response); error_response is None when access is granted.
+    """
+    shared_view = _share_token_grants(request, submission_id)
+    sub = None
+    if not shared_view:
+        sub, err = _require_submission_owner(request, submission_id)
+        if err:
+            return None, err
 
     conn, cursor = get_db_connection()
     if conn and cursor:
@@ -833,18 +873,18 @@ def submission_examples(submission_id: int):
             except Exception:
                 pass
         if not r:
-            return jsonify({"success": False, "error": "Not found"}), 404
+            return None, (jsonify({"success": False, "error": "Not found"}), 404)
         owner = r.get("submitter_id") or r.get("submitted_by") or ""
-        if owner != sub:
-            return jsonify({"success": False, "error": "Forbidden"}), 403
+        if not shared_view and owner != sub:
+            return None, (jsonify({"success": False, "error": "Forbidden"}), 403)
         raw_det = r.get("evaluation_details") or "{}"
     else:
         sub_row = next((s for s in _STORE["submissions"] if s["id"] == submission_id), None)
         if not sub_row:
-            return jsonify({"success": False, "error": "Not found"}), 404
+            return None, (jsonify({"success": False, "error": "Not found"}), 404)
         owner = sub_row.get("submitter_id") or sub_row.get("submitted_by")
-        if owner != sub:
-            return jsonify({"success": False, "error": "Forbidden"}), 403
+        if not shared_view and owner != sub:
+            return None, (jsonify({"success": False, "error": "Forbidden"}), 403)
         ev = next((e for e in _STORE["evaluations"] if e["submission_id"] == submission_id), None)
         raw_det = (ev or {}).get("evaluation_details") or "{}"
 
@@ -853,12 +893,43 @@ def submission_examples(submission_id: int):
     except Exception:
         det = {}
 
-    all_items: List[Dict[str, Any]] = det.get("item_results") or (det.get("detailed_scores") or {}).get("item_results") or []
-    if filter_by == "correct":
-        all_items = [it for it in all_items if it.get("correct") is True]
-    elif filter_by == "wrong":
-        all_items = [it for it in all_items if it.get("correct") is False]
+    items: List[Dict[str, Any]] = det.get("item_results") or (det.get("detailed_scores") or {}).get("item_results") or []
+    return items, None
 
+
+def _filter_examples(items: List[Dict[str, Any]], filter_by: str) -> List[Dict[str, Any]]:
+    if filter_by == "correct":
+        return [it for it in items if it.get("correct") is True]
+    if filter_by == "wrong":
+        return [it for it in items if it.get("correct") is False]
+    return items
+
+
+@bp.get("/public/submissions/<int:submission_id>/examples")
+def submission_examples(submission_id: int):
+    """Per-example prediction results for a submission.
+
+    Query params:
+      filter  = all | correct | wrong   (default: all)
+      offset  = int (default 0)
+      limit   = int 1–500 (default 100)
+      share   = share token minted via POST /public/submissions/<id>/share
+                (grants read-only access without owner auth)
+    """
+    filter_by = request.args.get("filter", "all").lower()
+    if filter_by not in ("all", "correct", "wrong"):
+        return jsonify({"success": False, "error": "filter must be all, correct, or wrong"}), 400
+    try:
+        offset = max(0, int(request.args.get("offset", 0)))
+        limit = min(500, max(1, int(request.args.get("limit", 100))))
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "error": "offset and limit must be integers"}), 400
+
+    items, err = _load_submission_examples(request, submission_id)
+    if err:
+        return err
+
+    all_items = _filter_examples(items, filter_by)
     total = len(all_items)
     page = all_items[offset: offset + limit]
     return jsonify({
@@ -869,6 +940,116 @@ def submission_examples(submission_id: int):
         "offset": offset,
         "limit": limit,
         "examples": page,
+    })
+
+
+@bp.get("/public/submissions/<int:submission_id>/examples/export")
+def submission_examples_export(submission_id: int):
+    """Download per-example results as CSV (owner auth or share token).
+
+    Query params:
+      filter = all | correct | wrong   (default: all)
+      share  = share token (optional alternative to owner auth)
+    """
+    filter_by = request.args.get("filter", "all").lower()
+    if filter_by not in ("all", "correct", "wrong"):
+        return jsonify({"success": False, "error": "filter must be all, correct, or wrong"}), 400
+
+    items, err = _load_submission_examples(request, submission_id)
+    if err:
+        return err
+
+    def cell(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, (list, dict)):
+            return json.dumps(value, ensure_ascii=False)
+        return str(value)
+
+    out = StringIO()
+    writer = csv.writer(out)
+    writer.writerow(["id", "ground_truth", "prediction", "correct"])
+    for it in _filter_examples(items, filter_by):
+        correct = it.get("correct")
+        writer.writerow([
+            cell(it.get("id")),
+            cell(it.get("ground_truth")),
+            cell(it.get("prediction")),
+            "" if correct is None else str(bool(correct)).lower(),
+        ])
+
+    filename = f"submission-{submission_id}-examples-{filter_by}.csv"
+    return Response(
+        out.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@bp.post("/public/submissions/<int:submission_id>/share")
+def create_submission_share_link(submission_id: int):
+    """Mint a read-only share token for a submission's examples (owner only).
+
+    Optional JSON body: {"expires_in_days": 1–90} (default 30).
+    The token is stateless (HS256, LEADERBOARD_JWT_SECRET) and carries no ``sub``
+    claim, so it cannot be replayed as a login bearer token.
+    """
+    sub, err = _require_submission_owner(request, submission_id)
+    if err:
+        return err
+
+    conn, cursor = get_db_connection()
+    if conn and cursor:
+        try:
+            try:
+                cursor.execute(
+                    "SELECT ms.submitter_id, ms.submitted_by FROM model_submissions ms WHERE ms.id = %s",
+                    (submission_id,),
+                )
+            except Exception:
+                cursor.execute(
+                    "SELECT ms.submitted_by FROM model_submissions ms WHERE ms.id = %s",
+                    (submission_id,),
+                )
+            r = cursor.fetchone()
+        finally:
+            try:
+                cursor.close()
+                conn.close()
+            except Exception:
+                pass
+        if not r:
+            return jsonify({"success": False, "error": "Not found"}), 404
+        owner = r.get("submitter_id") or r.get("submitted_by") or ""
+    else:
+        sub_row = next((s for s in _STORE["submissions"] if s["id"] == submission_id), None)
+        if not sub_row:
+            return jsonify({"success": False, "error": "Not found"}), 404
+        owner = sub_row.get("submitter_id") or sub_row.get("submitted_by")
+    if owner != sub:
+        return jsonify({"success": False, "error": "Forbidden"}), 403
+
+    body = request.get_json(silent=True) or {}
+    try:
+        days = int(body.get("expires_in_days", _SHARE_DEFAULT_DAYS))
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "error": "expires_in_days must be an integer"}), 400
+    days = min(_SHARE_MAX_DAYS, max(1, days))
+
+    token = _mint_share_token(submission_id, days)
+    if not token:
+        return jsonify({
+            "success": False,
+            "error": "Share links require LEADERBOARD_JWT_SECRET to be configured",
+        }), 503
+
+    expires_at = datetime.now(timezone.utc) + timedelta(days=days)
+    return jsonify({
+        "success": True,
+        "submission_id": submission_id,
+        "share_token": token,
+        "expires_in_days": days,
+        "expires_at": expires_at.isoformat(),
     })
 
 

--- a/backend/tests/test_examples_share_export.py
+++ b/backend/tests/test_examples_share_export.py
@@ -1,0 +1,287 @@
+"""Prediction Inspector Phase 5 — share links and CSV export for per-example results."""
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+
+try:
+    import app as app_module
+except ImportError:
+    import backend.app as app_module  # type: ignore
+
+
+app = app_module.app
+
+SECRET = "dev-secret"
+
+
+def reset_store() -> None:
+    app_module._STORE["submissions"].clear()
+    app_module._STORE["evaluations"].clear()
+    app_module._STORE["datasets"].clear()
+    app_module._STORE.setdefault("submission_counts", {}).clear()
+    app_module.LEADERBOARD_DATA.clear()
+    app_module._AUTO_SEED_DONE = False
+
+
+def make_jwt(sub: str) -> str:
+    return pyjwt.encode({"sub": sub}, SECRET, algorithm="HS256")
+
+
+def auth_headers(sub: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {make_jwt(sub)}"}
+
+
+def seed_classification_dataset(name: str, n: int = 4) -> None:
+    app_module._STORE["datasets"].append({
+        "name": name,
+        "task_type": "text_classification",
+        "evaluation_metric": "accuracy",
+        "reference_data": {
+            "source_texts": [f"text {i}" for i in range(n)],
+            "labels": ["pos" if i % 2 == 0 else "neg" for i in range(n)],
+            "label_names": ["pos", "neg"],
+        },
+    })
+
+
+def submit(client, dataset: str, owner: str, results: list[str]) -> int:
+    resp = client.post("/public/submit_model", json={
+        "benchmarkDatasetName": dataset,
+        "modelName": f"{owner}-model",
+        "modelResults": results,
+        "sentence_ids": list(range(len(results))),
+    }, headers=auth_headers(owner))
+    assert resp.status_code == 200
+    return resp.get_json()["submission_id"]
+
+
+def setup_env(monkeypatch) -> None:
+    monkeypatch.setenv("DISABLE_RATE_LIMIT", "1")
+    monkeypatch.setenv("LEADERBOARD_JWT_SECRET", SECRET)
+    monkeypatch.delenv("LEADERBOARD_API_KEYS", raising=False)
+    monkeypatch.delenv("REQUIRE_API_KEY", raising=False)
+    monkeypatch.setattr(app_module, "get_db_connection", lambda: (None, None))
+    reset_store()
+
+
+def parse_csv(body: bytes) -> list[dict[str, str]]:
+    return list(csv.DictReader(io.StringIO(body.decode("utf-8"))))
+
+
+# ---------------------------------------------------------------------------
+# CSV export
+# ---------------------------------------------------------------------------
+
+def test_export_csv_as_owner(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("export_ds")
+
+    with app.test_client() as c:
+        # ids 0,1 correct; 2,3 wrong
+        sid = submit(c, "export_ds", "owner-1", ["pos", "neg", "neg", "pos"])
+
+        r = c.get(f"/public/submissions/{sid}/examples/export", headers=auth_headers("owner-1"))
+        assert r.status_code == 200
+        assert r.mimetype == "text/csv"
+        assert f"submission-{sid}-examples-all.csv" in r.headers.get("Content-Disposition", "")
+
+        rows = parse_csv(r.data)
+        assert len(rows) == 4
+        assert rows[0]["ground_truth"] == "pos"
+        assert rows[0]["prediction"] == "pos"
+        assert rows[0]["correct"] == "true"
+        assert rows[2]["correct"] == "false"
+
+
+def test_export_csv_respects_filter(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("export_filter_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "export_filter_ds", "owner-2", ["pos", "neg", "neg", "pos"])
+
+        r = c.get(
+            f"/public/submissions/{sid}/examples/export?filter=wrong",
+            headers=auth_headers("owner-2"),
+        )
+        assert r.status_code == 200
+        rows = parse_csv(r.data)
+        assert len(rows) == 2
+        assert all(row["correct"] == "false" for row in rows)
+
+        bad = c.get(
+            f"/public/submissions/{sid}/examples/export?filter=bogus",
+            headers=auth_headers("owner-2"),
+        )
+        assert bad.status_code == 400
+
+
+def test_export_csv_requires_auth(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("export_auth_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "export_auth_ds", "owner-3", ["pos", "neg", "neg", "pos"])
+
+        assert c.get(f"/public/submissions/{sid}/examples/export").status_code == 401
+        other = c.get(
+            f"/public/submissions/{sid}/examples/export",
+            headers=auth_headers("someone-else"),
+        )
+        assert other.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Share links
+# ---------------------------------------------------------------------------
+
+def test_share_mint_and_anonymous_access(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_ds", "share-owner", ["pos", "neg", "neg", "pos"])
+
+        minted = c.post(f"/public/submissions/{sid}/share", headers=auth_headers("share-owner"))
+        assert minted.status_code == 200
+        body = minted.get_json()
+        assert body["success"] is True
+        assert body["expires_in_days"] == 30
+        token = body["share_token"]
+
+        # Anonymous read via share token
+        r = c.get(f"/public/submissions/{sid}/examples?share={token}")
+        assert r.status_code == 200
+        payload = r.get_json()
+        assert payload["total"] == 4
+        assert len(payload["examples"]) == 4
+
+        # Share token also unlocks CSV export
+        exp = c.get(f"/public/submissions/{sid}/examples/export?share={token}")
+        assert exp.status_code == 200
+        assert len(parse_csv(exp.data)) == 4
+
+        # Without the token, anonymous access stays locked
+        assert c.get(f"/public/submissions/{sid}/examples").status_code == 401
+
+
+def test_share_mint_requires_owner(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_owner_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_owner_ds", "real-owner", ["pos", "neg", "neg", "pos"])
+
+        assert c.post(f"/public/submissions/{sid}/share").status_code == 401
+        other = c.post(f"/public/submissions/{sid}/share", headers=auth_headers("intruder"))
+        assert other.status_code == 403
+        missing = c.post("/public/submissions/999999/share", headers=auth_headers("real-owner"))
+        assert missing.status_code == 404
+
+
+def test_share_expires_in_days_clamped_and_validated(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_clamp_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_clamp_ds", "clamp-owner", ["pos", "neg", "neg", "pos"])
+
+        big = c.post(
+            f"/public/submissions/{sid}/share",
+            json={"expires_in_days": 500},
+            headers=auth_headers("clamp-owner"),
+        )
+        assert big.status_code == 200
+        assert big.get_json()["expires_in_days"] == 90
+
+        bad = c.post(
+            f"/public/submissions/{sid}/share",
+            json={"expires_in_days": "abc"},
+            headers=auth_headers("clamp-owner"),
+        )
+        assert bad.status_code == 400
+
+
+def test_share_token_scoped_to_one_submission(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_scope_ds")
+
+    with app.test_client() as c:
+        sid_a = submit(c, "share_scope_ds", "scope-owner", ["pos", "neg", "neg", "pos"])
+        sid_b = submit(c, "share_scope_ds", "scope-owner", ["pos", "neg", "pos", "neg"])
+
+        token_a = c.post(
+            f"/public/submissions/{sid_a}/share", headers=auth_headers("scope-owner")
+        ).get_json()["share_token"]
+
+        assert c.get(f"/public/submissions/{sid_a}/examples?share={token_a}").status_code == 200
+        # Token for A must not open B
+        assert c.get(f"/public/submissions/{sid_b}/examples?share={token_a}").status_code == 401
+
+
+def test_share_token_expired_or_tampered_rejected(monkeypatch):
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_bad_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_bad_ds", "bad-owner", ["pos", "neg", "neg", "pos"])
+
+        expired = pyjwt.encode({
+            "share_submission_id": sid,
+            "scope": "submission-examples",
+            "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+        }, SECRET, algorithm="HS256")
+        assert c.get(f"/public/submissions/{sid}/examples?share={expired}").status_code == 401
+
+        wrong_key = pyjwt.encode({
+            "share_submission_id": sid,
+            "scope": "submission-examples",
+            "exp": datetime.now(timezone.utc) + timedelta(days=1),
+        }, "other-secret", algorithm="HS256")
+        assert c.get(f"/public/submissions/{sid}/examples?share={wrong_key}").status_code == 401
+
+        wrong_scope = pyjwt.encode({
+            "share_submission_id": sid,
+            "scope": "something-else",
+            "exp": datetime.now(timezone.utc) + timedelta(days=1),
+        }, SECRET, algorithm="HS256")
+        assert c.get(f"/public/submissions/{sid}/examples?share={wrong_scope}").status_code == 401
+
+
+def test_share_token_is_not_a_login_token(monkeypatch):
+    """A share token has no sub claim, so it must not authenticate owner-scoped routes."""
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_sec_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_sec_ds", "sec-owner", ["pos", "neg", "neg", "pos"])
+
+        token = c.post(
+            f"/public/submissions/{sid}/share", headers=auth_headers("sec-owner")
+        ).get_json()["share_token"]
+
+        as_bearer = {"Authorization": f"Bearer {token}"}
+        assert c.get("/public/my_submissions", headers=as_bearer).status_code == 401
+        assert c.get(f"/public/submissions/{sid}", headers=as_bearer).status_code == 401
+        assert c.delete(f"/public/submissions/{sid}", headers=as_bearer).status_code == 401
+
+
+def test_share_mint_requires_secret(monkeypatch):
+    """Without LEADERBOARD_JWT_SECRET, minting fails with 503 (owner authed via API key)."""
+    setup_env(monkeypatch)
+    seed_classification_dataset("share_nosecret_ds")
+
+    with app.test_client() as c:
+        sid = submit(c, "share_nosecret_ds", "key-owner", ["pos", "neg", "neg", "pos"])
+
+        monkeypatch.delenv("LEADERBOARD_JWT_SECRET", raising=False)
+        monkeypatch.setenv("LEADERBOARD_API_KEYS", "k1")
+        r = c.post(
+            f"/public/submissions/{sid}/share?submitter_id=key-owner",
+            headers={"X-API-Key": "k1"},
+        )
+        assert r.status_code == 503

--- a/frontend/src/landing_page/landing_page_components/SubmissionExamples.js
+++ b/frontend/src/landing_page/landing_page_components/SubmissionExamples.js
@@ -1,9 +1,10 @@
 import { useEffect, useState, useCallback } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { getLeaderboardJwt } from "../../utils/leaderboardAuth";
 import { loginPath } from "../../constants/RouteConstants";
 
-const PAGE_SIZE = 25;
+const PAGE_SIZES = [25, 50, 100];
+const FILTERS = ["all", "correct", "wrong"];
 
 function CorrectBadge({ correct }) {
   if (correct === true) return (
@@ -26,55 +27,136 @@ function CorrectBadge({ correct }) {
 export default function SubmissionExamples() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const API_BASE = process.env.REACT_APP_API_BASE || process.env.REACT_APP_API_ENDPOINT || "http://localhost:5001";
 
-  const [filter, setFilter] = useState("all");
-  const [offset, setOffset] = useState(0);
+  // View state lives in the URL so any view is linkable/bookmarkable.
+  const shareToken = searchParams.get("share") || "";
+  const rawFilter = searchParams.get("filter") || "all";
+  const filter = FILTERS.includes(rawFilter) ? rawFilter : "all";
+  const rawSize = parseInt(searchParams.get("size") || "", 10);
+  const pageSize = PAGE_SIZES.includes(rawSize) ? rawSize : PAGE_SIZES[0];
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10) || 1);
+  const offset = (page - 1) * pageSize;
+  const isSharedView = Boolean(shareToken);
+
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [exporting, setExporting] = useState(false);
+  const [shareState, setShareState] = useState("idle"); // idle | working | copied
 
-  const fetchExamples = useCallback(async (f, o) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const jwt = getLeaderboardJwt();
-      const headers = jwt ? { Authorization: `Bearer ${jwt}` } : {};
-      const url = new URL(`${API_BASE}/public/submissions/${id}/examples`);
-      url.searchParams.set("filter", f);
-      url.searchParams.set("offset", o);
-      url.searchParams.set("limit", PAGE_SIZE);
-      const res = await fetch(url.toString(), { headers });
-      const json = await res.json();
-      if (res.status === 401) { setError("auth"); return; }
-      if (res.status === 403) { setError("forbidden"); return; }
-      if (!res.ok || json.success === false) {
-        setError(json.error || "Failed to load examples");
-        return;
-      }
-      setData(json);
-    } catch (e) {
-      setError(e.message || "Network error");
-    } finally {
-      setLoading(false);
-    }
-  }, [API_BASE, id]);
+  const updateParams = useCallback((updates) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      Object.entries(updates).forEach(([k, v]) => {
+        if (v === null || v === undefined || v === "") next.delete(k);
+        else next.set(k, String(v));
+      });
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
 
   useEffect(() => {
-    setOffset(0);
-    fetchExamples(filter, 0);
-  }, [filter, fetchExamples]);
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const jwt = getLeaderboardJwt();
+        const headers = !shareToken && jwt ? { Authorization: `Bearer ${jwt}` } : {};
+        const url = new URL(`${API_BASE}/public/submissions/${id}/examples`);
+        url.searchParams.set("filter", filter);
+        url.searchParams.set("offset", offset);
+        url.searchParams.set("limit", pageSize);
+        if (shareToken) url.searchParams.set("share", shareToken);
+        const res = await fetch(url.toString(), { headers });
+        const json = await res.json();
+        if (cancelled) return;
+        if (res.status === 401) { setError(shareToken ? "share-invalid" : "auth"); return; }
+        if (res.status === 403) { setError("forbidden"); return; }
+        if (!res.ok || json.success === false) {
+          setError(json.error || "Failed to load examples");
+          return;
+        }
+        setData(json);
+      } catch (e) {
+        if (!cancelled) setError(e.message || "Network error");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [API_BASE, id, filter, offset, pageSize, shareToken]);
 
-  const handlePage = (newOffset) => {
-    setOffset(newOffset);
-    fetchExamples(filter, newOffset);
+  const setFilter = (f) => updateParams({ filter: f === "all" ? null : f, page: null });
+  const setPage = (p) => updateParams({ page: p <= 1 ? null : p });
+  const setPageSize = (s) => updateParams({ size: s === PAGE_SIZES[0] ? null : s, page: null });
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const url = new URL(`${API_BASE}/public/submissions/${id}/examples/export`);
+      url.searchParams.set("filter", filter);
+      if (shareToken) url.searchParams.set("share", shareToken);
+      const jwt = getLeaderboardJwt();
+      const headers = !shareToken && jwt ? { Authorization: `Bearer ${jwt}` } : {};
+      const res = await fetch(url.toString(), { headers });
+      if (!res.ok) throw new Error(`Export failed (${res.status})`);
+      const blob = await res.blob();
+      const objectUrl = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = `submission-${id}-examples-${filter}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(objectUrl);
+    } catch (e) {
+      window.alert(e.message || "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleShare = async () => {
+    setShareState("working");
+    try {
+      const jwt = getLeaderboardJwt();
+      const res = await fetch(`${API_BASE}/public/submissions/${id}/share`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+        },
+        body: JSON.stringify({}),
+      });
+      const json = await res.json();
+      if (!res.ok || json.success === false) {
+        throw new Error(json.error || `Could not create share link (${res.status})`);
+      }
+      const shareUrl = new URL(window.location.href);
+      shareUrl.searchParams.set("share", json.share_token);
+      shareUrl.searchParams.delete("page");
+      try {
+        await navigator.clipboard.writeText(shareUrl.toString());
+        setShareState("copied");
+        setTimeout(() => setShareState("idle"), 2500);
+      } catch {
+        setShareState("idle");
+        window.prompt("Copy this read-only share link:", shareUrl.toString());
+      }
+    } catch (e) {
+      setShareState("idle");
+      window.alert(e.message || "Could not create share link");
+    }
   };
 
   const total = data?.total ?? 0;
   const examples = data?.examples ?? [];
   const correctCount = data?.examples?.filter((e) => e.correct === true).length ?? 0;
-  const totalPages = Math.ceil(total / PAGE_SIZE);
-  const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const currentPage = Math.min(page, totalPages);
 
   const filterTabs = [
     { value: "all", label: "All" },
@@ -82,11 +164,14 @@ export default function SubmissionExamples() {
     { value: "wrong", label: "Wrong" },
   ];
 
+  const actionBtn = "px-3.5 py-1.5 rounded-lg border border-gray-700 text-xs font-semibold text-gray-300 hover:text-white hover:border-gray-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors";
+  const pageBtn = "px-3 py-1.5 rounded-lg border border-gray-700 text-xs text-gray-400 hover:text-white hover:border-gray-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors";
+
   return (
     <div className="flex flex-col items-center min-h-screen bg-[#111827] pb-24 px-4 text-gray-100">
       <div className="w-full max-w-5xl mt-10">
         {/* Header */}
-        <div className="flex items-center gap-3 mb-6">
+        <div className="flex items-center gap-3 mb-6 flex-wrap">
           <button
             type="button"
             onClick={() => navigate(-1)}
@@ -99,6 +184,11 @@ export default function SubmissionExamples() {
           <span className="text-xs text-gray-500 font-mono bg-gray-800/60 px-2 py-0.5 rounded">
             submission #{id}
           </span>
+          {isSharedView && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold bg-sky-500/15 text-sky-300 border border-sky-400/30">
+              Read-only shared view
+            </span>
+          )}
         </div>
 
         {/* Auth error */}
@@ -116,6 +206,14 @@ export default function SubmissionExamples() {
           </div>
         )}
 
+        {/* Invalid or expired share link */}
+        {error === "share-invalid" && (
+          <div className="rounded-xl border border-yellow-500/40 bg-yellow-500/10 px-5 py-8 text-center">
+            <p className="text-yellow-100 font-semibold">This share link is invalid or has expired.</p>
+            <p className="text-yellow-300/70 text-sm mt-1">Ask the submitter for a fresh link.</p>
+          </div>
+        )}
+
         {/* Forbidden */}
         {error === "forbidden" && (
           <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-5 py-8 text-center">
@@ -125,7 +223,7 @@ export default function SubmissionExamples() {
         )}
 
         {/* Generic error */}
-        {error && error !== "auth" && error !== "forbidden" && (
+        {error && !["auth", "forbidden", "share-invalid"].includes(error) && (
           <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-red-200 text-sm">
             {error}
           </div>
@@ -163,23 +261,48 @@ export default function SubmissionExamples() {
               )}
             </div>
 
-            {/* Filter tabs */}
-            <div className="flex gap-2 mb-4">
-              {filterTabs.map((t) => (
+            {/* Filter tabs + actions */}
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <div className="flex gap-2">
+                {filterTabs.map((t) => (
+                  <button
+                    key={t.value}
+                    type="button"
+                    onClick={() => setFilter(t.value)}
+                    className={[
+                      "px-3.5 py-1.5 rounded-full text-xs font-semibold border transition-colors",
+                      filter === t.value
+                        ? "bg-[#defe47]/10 border-[#defe47]/50 text-[#defe47]"
+                        : "bg-transparent border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
+                    ].join(" ")}
+                  >
+                    {t.label}
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-2">
                 <button
-                  key={t.value}
                   type="button"
-                  onClick={() => setFilter(t.value)}
-                  className={[
-                    "px-3.5 py-1.5 rounded-full text-xs font-semibold border transition-colors",
-                    filter === t.value
-                      ? "bg-[#defe47]/10 border-[#defe47]/50 text-[#defe47]"
-                      : "bg-transparent border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
-                  ].join(" ")}
+                  onClick={handleExport}
+                  disabled={exporting || total === 0}
+                  className={actionBtn}
                 >
-                  {t.label}
+                  {exporting ? "Exporting…" : "⬇ Export CSV"}
                 </button>
-              ))}
+                {!isSharedView && (
+                  <button
+                    type="button"
+                    onClick={handleShare}
+                    disabled={shareState === "working"}
+                    className={[
+                      actionBtn,
+                      shareState === "copied" ? "border-emerald-400/50 text-emerald-300" : "",
+                    ].join(" ")}
+                  >
+                    {shareState === "copied" ? "✓ Link copied" : shareState === "working" ? "Creating…" : "🔗 Share"}
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Table */}
@@ -247,31 +370,61 @@ export default function SubmissionExamples() {
                 </div>
 
                 {/* Pagination */}
-                {totalPages > 1 && (
-                  <div className="flex items-center justify-between px-4 py-3 border-t border-gray-800/40">
+                <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-t border-gray-800/40">
+                  <div className="flex items-center gap-3">
                     <span className="text-xs text-gray-500">
                       Page {currentPage} of {totalPages} · {total} examples
                     </span>
+                    <label className="flex items-center gap-1.5 text-xs text-gray-500">
+                      Rows
+                      <select
+                        value={pageSize}
+                        onChange={(e) => setPageSize(Number(e.target.value))}
+                        className="bg-[#111827] border border-gray-700 rounded-lg px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-gray-500"
+                      >
+                        {PAGE_SIZES.map((s) => (
+                          <option key={s} value={s}>{s}</option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                  {totalPages > 1 && (
                     <div className="flex gap-2">
                       <button
                         type="button"
-                        disabled={offset === 0}
-                        onClick={() => handlePage(Math.max(0, offset - PAGE_SIZE))}
-                        className="px-3 py-1.5 rounded-lg border border-gray-700 text-xs text-gray-400 hover:text-white hover:border-gray-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        disabled={currentPage <= 1}
+                        onClick={() => setPage(1)}
+                        className={pageBtn}
+                      >
+                        « First
+                      </button>
+                      <button
+                        type="button"
+                        disabled={currentPage <= 1}
+                        onClick={() => setPage(currentPage - 1)}
+                        className={pageBtn}
                       >
                         ← Prev
                       </button>
                       <button
                         type="button"
-                        disabled={offset + PAGE_SIZE >= total}
-                        onClick={() => handlePage(offset + PAGE_SIZE)}
-                        className="px-3 py-1.5 rounded-lg border border-gray-700 text-xs text-gray-400 hover:text-white hover:border-gray-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        disabled={currentPage >= totalPages}
+                        onClick={() => setPage(currentPage + 1)}
+                        className={pageBtn}
                       >
                         Next →
                       </button>
+                      <button
+                        type="button"
+                        disabled={currentPage >= totalPages}
+                        onClick={() => setPage(totalPages)}
+                        className={pageBtn}
+                      >
+                        Last »
+                      </button>
                     </div>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary

Phase 5 of the Prediction Inspector (the final planned phase of the summer feature): per-example prediction results were **owner-only and view-only** — you couldn't hand a teammate a link to your error analysis or pull the rows into a spreadsheet. This PR adds both, plus pagination polish.

### Share links (no schema change)
- `POST /public/submissions/<id>/share` (owner only) mints a **stateless read-only share token** — HS256 signed with the existing `LEADERBOARD_JWT_SECRET`, so no DB migration is needed.
- Expiry defaults to 30 days, clamped to 1–90 via `{"expires_in_days": n}`.
- `GET /public/submissions/<id>/examples` (and the new export route) accept `?share=<token>` as an alternative to owner auth.
- **Security:** tokens are scoped to a single submission id and carry no `sub` claim, so a share token can never be replayed as a login bearer token (covered by tests).

### CSV export
- `GET /public/submissions/<id>/examples/export` streams `id, ground_truth, prediction, correct` as a CSV attachment, respecting the `filter=all|correct|wrong` param. Works with owner auth or a share token.

### Frontend (`SubmissionExamples.js`)
- **🔗 Share** button creates the link and copies it to the clipboard ("✓ Link copied" feedback). Visitors on a shared link get a "Read-only shared view" badge, and expired/tampered links show a friendly "invalid or expired" message instead of a sign-in prompt.
- **⬇ Export CSV** button downloads the current filter's rows.
- Filter, page, and page size now **sync to the URL**, so any view is linkable/bookmarkable; added a rows-per-page selector (25/50/100) and First/Last pagination buttons.

Also updates the OpenAPI spec, the AGENTS.md route list, and adds a project `verify` skill capturing the end-to-end verification recipe.

## Test plan

- [x] 10 new backend tests (`backend/tests/test_examples_share_export.py`): export content/filter/auth, share mint ownership/404, token scoping to one submission, expired/tampered/wrong-scope rejection, expiry clamping, share-token-as-bearer replay rejection, missing-secret 503. Full suite: **112 passed**.
- [x] Ruff `E9,F63,F7,F82` clean; `npm run lint` clean; production build passes.
- [x] **End-to-end against a running backend (SQLite path)**: minted a share link over HTTP, read examples anonymously with it, downloaded CSVs (owner + shared, filtered), and confirmed 401/403/400/404 on tampered tokens, cross-submission tokens, replay-as-login, bad filters, and non-owner mints.
- [x] **Drove the built React app in headless Chrome**: shared view renders with badge and no Share button, filter clicks update the URL and keep the token, Export CSV produces a real download with correct rows, Share click puts the URL on the clipboard, invalid links show the expired message, page-size selector works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)